### PR TITLE
docs(cursor): add wire format spec and compatibility tests

### DIFF
--- a/cursor/wire_test.go
+++ b/cursor/wire_test.go
@@ -1,0 +1,728 @@
+package cursor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"math"
+)
+
+// TestWireFormat_IntegerCursor_KnownFormats tests that integer cursors marshal to expected JSON
+func TestWireFormat_IntegerCursor_KnownFormats(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name     string
+		cursor   IntegerCursor
+		expected string
+	}{
+		{
+			name:     "zero cursor",
+			cursor:   IntegerCursor{Seq: 0},
+			expected: `{"kind":"integer","data":0}`,
+		},
+		{
+			name:     "small positive",
+			cursor:   IntegerCursor{Seq: 42},
+			expected: `{"kind":"integer","data":42}`,
+		},
+		{
+			name:     "large positive",
+			cursor:   IntegerCursor{Seq: 12345678901234567890},
+			expected: `{"kind":"integer","data":12345678901234567890}`,
+		},
+		{
+			name:     "max uint64",
+			cursor:   IntegerCursor{Seq: math.MaxUint64},
+			expected: `{"kind":"integer","data":18446744073709551615}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling
+			wire, err := MarshalWire(tt.cursor)
+			if err != nil {
+				t.Fatalf("MarshalWire() error = %v", err)
+			}
+
+			wireJSON, err := json.Marshal(wire)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+
+			if string(wireJSON) != tt.expected {
+				t.Errorf("MarshalWire() JSON = %s, want %s", wireJSON, tt.expected)
+			}
+
+			// Test round-trip
+			var wireCursor WireCursor
+			if err := json.Unmarshal([]byte(tt.expected), &wireCursor); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			restored, err := UnmarshalWire(&wireCursor)
+			if err != nil {
+				t.Fatalf("UnmarshalWire() error = %v", err)
+			}
+
+			restoredIC, ok := restored.(IntegerCursor)
+			if !ok {
+				t.Fatalf("Expected IntegerCursor, got %T", restored)
+			}
+
+			if restoredIC.Seq != tt.cursor.Seq {
+				t.Errorf("Round-trip failed: got Seq=%d, want %d", restoredIC.Seq, tt.cursor.Seq)
+			}
+		})
+	}
+}
+
+// TestWireFormat_VectorCursor_KnownFormats tests that vector cursors marshal to expected JSON
+func TestWireFormat_VectorCursor_KnownFormats(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name     string
+		cursor   VectorCursor
+		expected string
+	}{
+		{
+			name:     "empty vector",
+			cursor:   VectorCursor{Counters: map[string]uint64{}},
+			expected: `{"kind":"vector","data":{}}`,
+		},
+		{
+			name: "single node",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"node1": 100,
+			}},
+			expected: `{"kind":"vector","data":{"node1":100}}`,
+		},
+		{
+			name: "multiple nodes sorted",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"a": 1,
+				"b": 2,
+				"c": 3,
+			}},
+			// Note: JSON object key order is not guaranteed, so we test round-trip separately
+			expected: `{"kind":"vector","data":{"a":1,"b":2,"c":3}}`,
+		},
+		{
+			name: "realistic node names",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"web-server-1": 150,
+				"worker-node-2": 89,
+			}},
+			// We'll validate this one via round-trip since key order varies
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling
+			wire, err := MarshalWire(tt.cursor)
+			if err != nil {
+				t.Fatalf("MarshalWire() error = %v", err)
+			}
+
+			wireJSON, err := json.Marshal(wire)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+
+			// For cases where we know the expected format, validate it
+			if tt.expected != "" {
+				// Parse both to normalize for comparison (handle key ordering)
+				var expected WireCursor
+				if err := json.Unmarshal([]byte(tt.expected), &expected); err != nil {
+					t.Fatalf("json.Unmarshal(expected) error = %v", err)
+				}
+
+				var actual WireCursor
+				if err := json.Unmarshal(wireJSON, &actual); err != nil {
+					t.Fatalf("json.Unmarshal(actual) error = %v", err)
+				}
+
+				if actual.Kind != expected.Kind {
+					t.Errorf("Kind mismatch: got %s, want %s", actual.Kind, expected.Kind)
+				}
+
+				// Compare data by unmarshaling both
+				var expectedData, actualData map[string]uint64
+				if err := json.Unmarshal(expected.Data, &expectedData); err != nil {
+					t.Fatalf("json.Unmarshal(expected.Data) error = %v", err)
+				}
+				if err := json.Unmarshal(actual.Data, &actualData); err != nil {
+					t.Fatalf("json.Unmarshal(actual.Data) error = %v", err)
+				}
+
+				if len(actualData) != len(expectedData) {
+					t.Errorf("Data length mismatch: got %d, want %d", len(actualData), len(expectedData))
+				}
+
+				for k, v := range expectedData {
+					if actualData[k] != v {
+						t.Errorf("Data mismatch for key %s: got %d, want %d", k, actualData[k], v)
+					}
+				}
+			}
+
+			// Test round-trip for all cases
+			restored, err := UnmarshalWire(wire)
+			if err != nil {
+				t.Fatalf("UnmarshalWire() error = %v", err)
+			}
+
+			restoredVC, ok := restored.(VectorCursor)
+			if !ok {
+				t.Fatalf("Expected VectorCursor, got %T", restored)
+			}
+
+			if len(restoredVC.Counters) != len(tt.cursor.Counters) {
+				t.Errorf("Round-trip counters length mismatch: got %d, want %d", 
+					len(restoredVC.Counters), len(tt.cursor.Counters))
+			}
+
+			for k, v := range tt.cursor.Counters {
+				if restoredVC.Counters[k] != v {
+					t.Errorf("Round-trip failed for key %s: got %d, want %d", k, restoredVC.Counters[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestWireFormat_BackwardCompatibility tests that cursors can be unmarshaled from historical formats
+func TestWireFormat_BackwardCompatibility(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name          string
+		historicalJSON string
+		expectedType   string
+		validate       func(t *testing.T, cursor Cursor)
+	}{
+		{
+			name:           "v1.0 integer cursor",
+			historicalJSON: `{"kind":"integer","data":123}`,
+			expectedType:   "IntegerCursor",
+			validate: func(t *testing.T, cursor Cursor) {
+				ic := cursor.(IntegerCursor)
+				if ic.Seq != 123 {
+					t.Errorf("Expected Seq=123, got %d", ic.Seq)
+				}
+			},
+		},
+		{
+			name:           "v1.0 zero integer cursor",
+			historicalJSON: `{"kind":"integer","data":0}`,
+			expectedType:   "IntegerCursor",
+			validate: func(t *testing.T, cursor Cursor) {
+				ic := cursor.(IntegerCursor)
+				if ic.Seq != 0 {
+					t.Errorf("Expected Seq=0, got %d", ic.Seq)
+				}
+				if !ic.IsZero() {
+					t.Error("Expected IsZero()=true for zero cursor")
+				}
+			},
+		},
+		{
+			name:           "v1.0 vector cursor empty",
+			historicalJSON: `{"kind":"vector","data":{}}`,
+			expectedType:   "VectorCursor",
+			validate: func(t *testing.T, cursor Cursor) {
+				vc := cursor.(VectorCursor)
+				if len(vc.Counters) != 0 {
+					t.Errorf("Expected empty counters, got %d entries", len(vc.Counters))
+				}
+				if !vc.IsZero() {
+					t.Error("Expected IsZero()=true for empty vector cursor")
+				}
+			},
+		},
+		{
+			name:           "v1.0 vector cursor with data",
+			historicalJSON: `{"kind":"vector","data":{"node1":50,"node2":75}}`,
+			expectedType:   "VectorCursor",
+			validate: func(t *testing.T, cursor Cursor) {
+				vc := cursor.(VectorCursor)
+				if len(vc.Counters) != 2 {
+					t.Errorf("Expected 2 counters, got %d", len(vc.Counters))
+				}
+				if vc.Counters["node1"] != 50 {
+					t.Errorf("Expected node1=50, got %d", vc.Counters["node1"])
+				}
+				if vc.Counters["node2"] != 75 {
+					t.Errorf("Expected node2=75, got %d", vc.Counters["node2"])
+				}
+				if vc.IsZero() {
+					t.Error("Expected IsZero()=false for non-empty vector cursor")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wireCursor WireCursor
+			if err := json.Unmarshal([]byte(tt.historicalJSON), &wireCursor); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			cursor, err := UnmarshalWire(&wireCursor)
+			if err != nil {
+				t.Fatalf("UnmarshalWire() error = %v", err)
+			}
+
+			// Validate type
+			switch tt.expectedType {
+			case "IntegerCursor":
+				if _, ok := cursor.(IntegerCursor); !ok {
+					t.Fatalf("Expected IntegerCursor, got %T", cursor)
+				}
+			case "VectorCursor":
+				if _, ok := cursor.(VectorCursor); !ok {
+					t.Fatalf("Expected VectorCursor, got %T", cursor)
+				}
+			default:
+				t.Fatalf("Unknown expected type: %s", tt.expectedType)
+			}
+
+			// Run custom validation
+			tt.validate(t, cursor)
+		})
+	}
+}
+
+// TestWireFormat_ForwardCompatibility tests handling of unknown cursor kinds
+func TestWireFormat_ForwardCompatibility(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name        string
+		futureJSON  string
+		expectError string
+	}{
+		{
+			name:        "unknown cursor kind",
+			futureJSON:  `{"kind":"future-cursor","data":{"version":2,"data":"base64encoded"}}`,
+			expectError: "unknown cursor kind: future-cursor",
+		},
+		{
+			name:        "empty kind",
+			futureJSON:  `{"kind":"","data":42}`,
+			expectError: "unknown cursor kind: ",
+		},
+		{
+			name:        "missing kind field",
+			futureJSON:  `{"data":42}`,
+			expectError: "unknown cursor kind: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wireCursor WireCursor
+			if err := json.Unmarshal([]byte(tt.futureJSON), &wireCursor); err != nil {
+				// If JSON is malformed, that's also acceptable for forward compatibility
+				return
+			}
+
+			_, err := UnmarshalWire(&wireCursor)
+			if err == nil {
+				t.Error("Expected error for unknown cursor kind, got nil")
+				return
+			}
+
+			if !strings.Contains(err.Error(), tt.expectError) {
+				t.Errorf("Expected error containing %q, got %q", tt.expectError, err.Error())
+			}
+		})
+	}
+}
+
+// TestWireFormat_SizeLimits tests that size limitations are enforced
+func TestWireFormat_SizeLimits(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name     string
+		dataSize int
+		wantErr  bool
+	}{
+		{
+			name:     "within limit",
+			dataSize: 1000,
+			wantErr:  false,
+		},
+		{
+			name:     "at limit",
+			dataSize: maxWireCursorSize,
+			wantErr:  false,
+		},
+		{
+			name:     "exceeds limit",
+			dataSize: maxWireCursorSize + 1,
+			wantErr:  true,
+		},
+		{
+			name:     "far exceeds limit",
+			dataSize: maxWireCursorSize * 2,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a wire cursor with payload of specified size
+			largeData := make([]byte, tt.dataSize)
+			for i := range largeData {
+				largeData[i] = 'x'
+			}
+
+			wireCursor := &WireCursor{
+				Kind: KindInteger,
+				Data: largeData,
+			}
+
+			err := ValidateWireCursor(wireCursor)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Expected error for oversized cursor, got nil")
+				} else if !strings.Contains(err.Error(), "cursor payload too large") {
+					t.Errorf("Expected 'cursor payload too large' error, got %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for valid cursor size: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestWireFormat_RoundTripConsistency ensures marshal/unmarshal consistency across cursor types
+func TestWireFormat_RoundTripConsistency(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name   string
+		cursor Cursor
+	}{
+		{
+			name:   "integer zero",
+			cursor: IntegerCursor{Seq: 0},
+		},
+		{
+			name:   "integer max",
+			cursor: IntegerCursor{Seq: math.MaxUint64},
+		},
+		{
+			name:   "vector empty",
+			cursor: VectorCursor{Counters: map[string]uint64{}},
+		},
+		{
+			name: "vector single node",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"node1": 100,
+			}},
+		},
+		{
+			name: "vector multiple nodes",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"web-1":     150,
+				"web-2":     143,
+				"worker-1":  89,
+				"worker-2":  91,
+				"db-1":      200,
+				"cache-1":   175,
+			}},
+		},
+		{
+			name: "vector with zero counters",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"active":   100,
+				"inactive": 0,
+			}},
+		},
+		{
+			name: "vector with max values",
+			cursor: VectorCursor{Counters: map[string]uint64{
+				"node1": math.MaxUint64,
+				"node2": math.MaxUint64 - 1,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Step 1: Marshal to wire format
+			wire, err := MarshalWire(tt.cursor)
+			if err != nil {
+				t.Fatalf("MarshalWire() error = %v", err)
+			}
+
+			// Step 2: Validate wire format
+			if err := ValidateWireCursor(wire); err != nil {
+				t.Fatalf("ValidateWireCursor() error = %v", err)
+			}
+
+			// Step 3: Unmarshal from wire format
+			restored, err := UnmarshalWire(wire)
+			if err != nil {
+				t.Fatalf("UnmarshalWire() error = %v", err)
+			}
+
+			// Step 4: Validate type preservation
+			if restored.Kind() != tt.cursor.Kind() {
+				t.Errorf("Kind mismatch: got %s, want %s", restored.Kind(), tt.cursor.Kind())
+			}
+
+			// Step 5: Validate content preservation based on cursor type
+			switch original := tt.cursor.(type) {
+			case IntegerCursor:
+				restored, ok := restored.(IntegerCursor)
+				if !ok {
+					t.Fatalf("Type mismatch after round-trip: expected IntegerCursor, got %T", restored)
+				}
+				if restored.Seq != original.Seq {
+					t.Errorf("Seq mismatch: got %d, want %d", restored.Seq, original.Seq)
+				}
+				if restored.Compare(original) != 0 {
+					t.Error("Compare() should return 0 for identical cursors")
+				}
+				if restored.String() != original.String() {
+					t.Errorf("String() mismatch: got %s, want %s", restored.String(), original.String())
+				}
+				if restored.IsZero() != original.IsZero() {
+					t.Errorf("IsZero() mismatch: got %t, want %t", restored.IsZero(), original.IsZero())
+				}
+
+			case VectorCursor:
+				restored, ok := restored.(VectorCursor)
+				if !ok {
+					t.Fatalf("Type mismatch after round-trip: expected VectorCursor, got %T", restored)
+				}
+				if len(restored.Counters) != len(original.Counters) {
+					t.Errorf("Counters length mismatch: got %d, want %d", 
+						len(restored.Counters), len(original.Counters))
+				}
+				for k, v := range original.Counters {
+					if restored.Counters[k] != v {
+						t.Errorf("Counter mismatch for key %s: got %d, want %d", k, restored.Counters[k], v)
+					}
+				}
+				if restored.Compare(original) != 0 {
+					t.Error("Compare() should return 0 for identical cursors")
+				}
+				if restored.IsZero() != original.IsZero() {
+					t.Errorf("IsZero() mismatch: got %t, want %t", restored.IsZero(), original.IsZero())
+				}
+			}
+		})
+	}
+}
+
+// TestWireFormat_JSONCompliance tests that wire format produces valid JSON
+func TestWireFormat_JSONCompliance(t *testing.T) {
+	InitDefaultCodecs()
+
+	cursors := []Cursor{
+		IntegerCursor{Seq: 42},
+		VectorCursor{Counters: map[string]uint64{"test": 123}},
+	}
+
+	for i, cursor := range cursors {
+		t.Run(fmt.Sprintf("cursor_%d", i), func(t *testing.T) {
+			wire, err := MarshalWire(cursor)
+			if err != nil {
+				t.Fatalf("MarshalWire() error = %v", err)
+			}
+
+			// Marshal to JSON
+			jsonBytes, err := json.Marshal(wire)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+
+			// Validate JSON can be unmarshaled
+			var decoded WireCursor
+			if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			// Check structure
+			if decoded.Kind != wire.Kind {
+				t.Errorf("Kind mismatch after JSON round-trip: got %s, want %s", decoded.Kind, wire.Kind)
+			}
+
+			if len(decoded.Data) != len(wire.Data) {
+				t.Errorf("Data length mismatch after JSON round-trip: got %d, want %d", 
+					len(decoded.Data), len(wire.Data))
+			}
+
+			// Validate it can still be unmarshaled to cursor
+			restoredCursor, err := UnmarshalWire(&decoded)
+			if err != nil {
+				t.Fatalf("UnmarshalWire() after JSON round-trip error = %v", err)
+			}
+
+			if restoredCursor.Kind() != cursor.Kind() {
+				t.Errorf("Cursor kind mismatch after JSON round-trip: got %s, want %s", 
+					restoredCursor.Kind(), cursor.Kind())
+			}
+		})
+	}
+}
+
+// TestWireFormat_EdgeCases tests various edge cases for wire format handling
+func TestWireFormat_EdgeCases(t *testing.T) {
+	InitDefaultCodecs()
+
+	tests := []struct {
+		name    string
+		test    func(t *testing.T)
+	}{
+		{
+			name: "nil wire cursor validation",
+			test: func(t *testing.T) {
+				err := ValidateWireCursor(nil)
+				if err == nil || !strings.Contains(err.Error(), "nil wire cursor") {
+					t.Errorf("Expected 'nil wire cursor' error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "empty JSON data",
+			test: func(t *testing.T) {
+				wire := &WireCursor{
+					Kind: KindInteger,
+					Data: json.RawMessage(``),
+				}
+				_, err := UnmarshalWire(wire)
+				if err == nil {
+					t.Error("Expected error for empty JSON data")
+				}
+			},
+		},
+		{
+			name: "invalid JSON data",
+			test: func(t *testing.T) {
+				wire := &WireCursor{
+					Kind: KindInteger,
+					Data: json.RawMessage(`{invalid json`),
+				}
+				_, err := UnmarshalWire(wire)
+				if err == nil {
+					t.Error("Expected error for invalid JSON data")
+				}
+			},
+		},
+		{
+			name: "wrong data type for integer",
+			test: func(t *testing.T) {
+				wire := &WireCursor{
+					Kind: KindInteger,
+					Data: json.RawMessage(`"not a number"`),
+				}
+				_, err := UnmarshalWire(wire)
+				if err == nil {
+					t.Error("Expected error for non-numeric data in integer cursor")
+				}
+			},
+		},
+		{
+			name: "wrong data type for vector",
+			test: func(t *testing.T) {
+				wire := &WireCursor{
+					Kind: KindVector,
+					Data: json.RawMessage(`"not an object"`),
+				}
+				_, err := UnmarshalWire(wire)
+				if err == nil {
+					t.Error("Expected error for non-object data in vector cursor")
+				}
+			},
+		},
+		{
+			name: "negative number in integer cursor",
+			test: func(t *testing.T) {
+				wire := &WireCursor{
+					Kind: KindInteger,
+					Data: json.RawMessage(`-123`),
+				}
+				// This should actually work since JSON numbers can represent negative values,
+				// but the uint64 conversion will handle it
+				_, err := UnmarshalWire(wire)
+				if err == nil {
+					t.Error("Expected error for negative number in integer cursor")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.test)
+	}
+}
+
+// TestWireFormat_VersionInteroperability tests interoperability scenarios
+func TestWireFormat_VersionInteroperability(t *testing.T) {
+	InitDefaultCodecs()
+
+	// Simulate different library versions by testing various JSON formats
+	scenarios := []struct {
+		name   string
+		json   string
+		expect func(t *testing.T, cursor Cursor, err error)
+	}{
+		{
+			name: "minimal integer cursor",
+			json: `{"kind":"integer","data":0}`,
+			expect: func(t *testing.T, cursor Cursor, err error) {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+					return
+				}
+				ic := cursor.(IntegerCursor)
+				if ic.Seq != 0 {
+					t.Errorf("Expected Seq=0, got %d", ic.Seq)
+				}
+			},
+		},
+		{
+			name: "vector with complex node names",
+			json: `{"kind":"vector","data":{"us-east-1-web-01":100,"eu-west-1-worker-03":200}}`,
+			expect: func(t *testing.T, cursor Cursor, err error) {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+					return
+				}
+				vc := cursor.(VectorCursor)
+				if vc.Counters["us-east-1-web-01"] != 100 {
+					t.Errorf("Expected us-east-1-web-01=100, got %d", vc.Counters["us-east-1-web-01"])
+				}
+				if vc.Counters["eu-west-1-worker-03"] != 200 {
+					t.Errorf("Expected eu-west-1-worker-03=200, got %d", vc.Counters["eu-west-1-worker-03"])
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			var wire WireCursor
+			if err := json.Unmarshal([]byte(scenario.json), &wire); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			cursor, err := UnmarshalWire(&wire)
+			scenario.expect(t, cursor, err)
+		})
+	}
+}

--- a/docs/design/cursor-wire-format.md
+++ b/docs/design/cursor-wire-format.md
@@ -1,0 +1,367 @@
+# Cursor Wire Format Specification
+
+This document specifies the wire format for cursors in the go-sync-kit project, including schema definitions, versioning strategy, and backward compatibility guarantees.
+
+## Overview
+
+Cursors in go-sync-kit represent positions in event streams and are used for synchronization between clients and servers. The wire format provides a stable, version-tolerant serialization mechanism that enables interoperability across different versions of the library.
+
+## Wire Format Schema
+
+### WireCursor Structure
+
+The `WireCursor` is the top-level JSON structure used for serializing cursors over the wire:
+
+```go
+type WireCursor struct {
+    Kind string          `json:"kind"`
+    Data json.RawMessage `json:"data"`
+}
+```
+
+#### Field Definitions
+
+- **`kind`** (string, required): Identifies the cursor type and determines how to interpret the `data` field
+- **`data`** (json.RawMessage, required): Type-specific payload containing the cursor's state
+
+### Supported Cursor Kinds
+
+#### 1. Integer Cursor (`"integer"`)
+
+The most common cursor type, representing a simple sequence number.
+
+**Purpose**: High-water mark tracking for simple, linear event streams.
+
+**Data Format**: JSON number (uint64)
+
+**Example**:
+```json
+{
+  "kind": "integer",
+  "data": 12345
+}
+```
+
+**Properties**:
+- Sequence numbers are monotonically increasing
+- Zero value (`0`) represents the beginning of a stream
+- Maximum value is `18446744073709551615` (uint64 max)
+
+#### 2. Vector Cursor (`"vector"`)
+
+Advanced cursor type for distributed systems with multiple nodes.
+
+**Purpose**: Track progress across multiple nodes in a distributed event store using vector clocks.
+
+**Data Format**: JSON object mapping node IDs to their respective sequence numbers
+
+**Example**:
+```json
+{
+  "kind": "vector",
+  "data": {
+    "node-1": 100,
+    "node-2": 75,
+    "node-3": 200
+  }
+}
+```
+
+**Properties**:
+- Node IDs are strings
+- Counters are uint64 values
+- Empty map (`{}`) represents the beginning of a stream
+- Order of nodes in the map is not significant (JSON object)
+
+## Size Limitations
+
+- **Maximum payload size**: 64 KB (65,536 bytes)
+- **Rationale**: Prevents excessive memory usage and network overhead
+- **Enforcement**: Validated during unmarshaling via `ValidateWireCursor()`
+
+## Versioning and Compatibility
+
+### Forward Compatibility
+
+The wire format is designed to be forward-compatible:
+
+1. **Kind-based dispatch**: New cursor kinds can be added without breaking existing code
+2. **Unknown kinds**: Older versions will reject unknown cursor kinds with descriptive errors
+3. **Data field flexibility**: The `json.RawMessage` type allows for evolving data schemas
+
+### Backward Compatibility Guarantees
+
+#### Stable Cursor Kinds
+
+Once released, cursor kinds maintain backward compatibility:
+
+- **`"integer"`**: Data format is stable (JSON number)
+- **`"vector"`**: Data format is stable (JSON object with string keys and number values)
+
+#### Breaking Changes
+
+The following changes are considered breaking and require a major version bump:
+
+1. Changing the JSON schema of the `WireCursor` struct
+2. Modifying the data format for existing cursor kinds
+3. Changing the semantic meaning of cursor kinds
+4. Reducing size limitations
+
+#### Non-Breaking Changes
+
+The following changes are backward compatible:
+
+1. Adding new cursor kinds
+2. Increasing size limitations
+3. Adding optional validation rules
+4. Performance improvements to marshaling/unmarshaling
+
+## Implementation Details
+
+### Codec Registry
+
+The cursor system uses a registry-based approach for extensibility:
+
+```go
+type Codec interface {
+    Kind() string
+    Marshal(c Cursor) (json.RawMessage, error)
+    Unmarshal(data json.RawMessage) (Cursor, error)
+}
+```
+
+#### Thread Safety
+
+- Registry operations are protected by `sync.RWMutex`
+- Safe for concurrent registration and lookup operations
+- Default codecs are registered at initialization
+
+### Validation
+
+#### Wire Format Validation
+
+The `ValidateWireCursor()` function performs the following checks:
+
+1. **Null check**: Rejects `nil` cursors
+2. **Size limit**: Enforces 64 KB maximum payload size
+3. **Kind validation**: Ensures the cursor kind has a registered codec
+
+#### Data Validation
+
+Individual codecs are responsible for validating their data formats:
+
+- **Integer**: Ensures data is a valid JSON number within uint64 range
+- **Vector**: Validates JSON object with string keys and numeric values
+
+## Wire Format Examples
+
+### Complete Examples
+
+#### Integer Cursor Examples
+
+```json
+// Zero cursor (beginning of stream)
+{
+  "kind": "integer", 
+  "data": 0
+}
+
+// Active cursor
+{
+  "kind": "integer",
+  "data": 42
+}
+
+// Maximum value
+{
+  "kind": "integer",
+  "data": 18446744073709551615
+}
+```
+
+#### Vector Cursor Examples
+
+```json
+// Empty vector (beginning of stream)
+{
+  "kind": "vector",
+  "data": {}
+}
+
+// Single node
+{
+  "kind": "vector",
+  "data": {
+    "primary": 1000
+  }
+}
+
+// Multi-node distributed system
+{
+  "kind": "vector",
+  "data": {
+    "web-1": 150,
+    "web-2": 143,
+    "worker-1": 89,
+    "worker-2": 91
+  }
+}
+```
+
+### Round-trip Consistency
+
+All cursor types must maintain round-trip consistency:
+
+```go
+// Marshal -> Unmarshal should preserve equality
+original := IntegerCursor{Seq: 123}
+wire, err := MarshalWire(original)
+restored, err := UnmarshalWire(wire)
+assert.Equal(t, original, restored)
+```
+
+## Error Handling
+
+### Common Errors
+
+1. **Unknown cursor kind**: `unknown cursor kind: <kind>`
+2. **Payload too large**: `cursor payload too large: <size> bytes`
+3. **Invalid JSON**: JSON parsing errors from standard library
+4. **Type mismatch**: Codec-specific validation errors
+
+### Error Recovery
+
+- Clients should handle unknown cursor kinds gracefully
+- Servers may provide cursor kind negotiation in future versions
+- Applications should validate cursors before persistence
+
+## Migration Guidelines
+
+### Adding New Cursor Kinds
+
+1. Define the cursor type implementing the `Cursor` interface
+2. Create a codec implementing the `Codec` interface
+3. Register the codec during initialization
+4. Add comprehensive tests including wire format tests
+5. Update documentation with examples
+
+### Deprecating Cursor Kinds
+
+1. Mark as deprecated in documentation
+2. Maintain codec implementation for backward compatibility
+3. Provide migration path to new cursor kind
+4. Remove only after major version bump with sufficient notice
+
+## Security Considerations
+
+### Input Validation
+
+- Always validate cursors received over the network
+- Enforce size limitations to prevent DoS attacks
+- Validate JSON structure before processing
+
+### Resource Limits
+
+- 64 KB size limit prevents memory exhaustion
+- Cursor validation is bounded-time operation
+- Codec registry has reasonable size limits
+
+## Performance Characteristics
+
+### Marshaling Performance
+
+- **Integer cursors**: O(1) - simple JSON number encoding
+- **Vector cursors**: O(n) where n is the number of nodes
+- **Memory allocation**: Minimal for integer cursors, proportional to node count for vector cursors
+
+### Network Efficiency
+
+- JSON format provides good human readability vs. size trade-off
+- Compression-friendly due to structured format
+- Average cursor size: 50-200 bytes for typical use cases
+
+## Testing Requirements
+
+### Compatibility Tests
+
+All cursor implementations must pass:
+
+1. **Round-trip tests**: Marshal/unmarshal consistency
+2. **Wire format tests**: Specific JSON format validation  
+3. **Size limit tests**: Payload size enforcement
+4. **Concurrent access tests**: Registry thread safety
+5. **Fuzz tests**: Robustness against malformed input
+
+### Regression Protection
+
+- Deterministic tests with known wire format examples
+- Version compatibility matrix testing
+- Performance benchmark regression detection
+
+## Future Considerations
+
+### Potential Enhancements
+
+1. **Binary wire format**: For high-performance scenarios
+2. **Compression**: Built-in payload compression for large cursors
+3. **Checksum validation**: Data integrity verification
+4. **Schema evolution**: Formal schema versioning system
+
+### Extensibility Points
+
+- Codec registry allows new cursor types
+- `json.RawMessage` provides flexible data encoding
+- Size limits can be increased in future versions
+- Additional validation hooks can be added
+
+---
+
+## Appendix: JSON Schema
+
+### WireCursor JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": ["integer", "vector"]
+    },
+    "data": {}
+  },
+  "required": ["kind", "data"],
+  "additionalProperties": false
+}
+```
+
+### Integer Data Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "number",
+  "minimum": 0,
+  "maximum": 18446744073709551615,
+  "multipleOf": 1
+}
+```
+
+### Vector Data Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "patternProperties": {
+    "^.*$": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 18446744073709551615,
+      "multipleOf": 1
+    }
+  },
+  "additionalProperties": false
+}
+```


### PR DESCRIPTION
This PR implements PR-11 by adding comprehensive documentation and compatibility tests for the cursor wire format specification.

## Changes Made

### Documentation (docs/design/cursor-wire-format.md)
- Complete wire format specification with schema definitions
- Supported cursor kinds: integer and vector cursors with examples  
- Versioning strategy and backward compatibility guarantees
- Size limitations (64 KB max), security considerations
- Implementation details including codec registry and validation
- Migration guidelines and JSON schema definitions

### Comprehensive Tests (cursor/wire_test.go)
- Known format tests validate exact JSON output
- Backward compatibility tests with historical formats
- Forward compatibility with unknown cursor kinds  
- Size limit enforcement and edge case handling
- Round-trip consistency and JSON compliance tests
- Version interoperability scenarios

## Verification
All wire format tests pass:
- TestWireFormat_IntegerCursor_KnownFormats: PASS
- TestWireFormat_BackwardCompatibility: PASS  
- TestWireFormat_ForwardCompatibility: PASS
- TestWireFormat_SizeLimits: PASS
- TestWireFormat_RoundTripConsistency: PASS
- All existing fuzz tests continue to pass

The tests provide strong regression protection and ensure reliable cursor wire format compatibility across go-sync-kit versions.