### PR TITLE
fix: handle nil offset returns gracefully in projection runner

### DIFF
--- a/projection/runner.go
+++ b/projection/runner.go
@@ -22,6 +22,31 @@ type runner struct {
 	metrics        *metrics.SyncKitMetrics // Integrated metrics system
 }
 
+// getStartVersion determines the starting version for projection processing.
+// It handles the documented nil return from OffsetStore.Get gracefully by using
+// the event store's zero version when no offset has been stored yet.
+func (r *runner) getStartVersion(ctx context.Context) (synckit.Version, error) {
+	projectionName := r.projector.Name()
+	
+	offset, err := r.offsets.Get(ctx, projectionName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get offset for projection %s: %w", projectionName, err)
+	}
+	
+	if offset != nil {
+		return offset, nil
+	}
+	
+	// No stored offset - start from beginning
+	// Use store's ParseVersion with empty string to get zero version
+	zeroVersion, err := r.store.ParseVersion(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create zero version for projection start: %w", err)
+	}
+	
+	return zeroVersion, nil
+}
+
 // ApplySince applies all events since the last saved offset.
 // Returns the number of events applied, the last processed version, and any error.
 func (r *runner) ApplySince(ctx context.Context) (applied int, last synckit.Version, err error) {
@@ -39,8 +64,8 @@ func (r *runner) ApplySince(ctx context.Context) (applied int, last synckit.Vers
 		}
 	}()
 	
-	// Get the last applied version from the offset store
-	lastVersion, err := r.offsets.Get(ctx, projectionName)
+	// Get the starting version, handling nil offset gracefully
+	startVersion, err := r.getStartVersion(ctx)
 	if err != nil {
 		if r.metricsEnabled && r.metrics != nil {
 			r.metrics.RecordProjectionError(projectionName, OperationApplySince, ErrorTypeOffset)
@@ -48,19 +73,19 @@ func (r *runner) ApplySince(ctx context.Context) (applied int, last synckit.Vers
 		return 0, nil, errors.E(
 			errors.Op("runner.ApplySince"),
 			errors.Component("projection"),
-			fmt.Errorf("failed to get last offset for projection %s: %w", projectionName, err),
+			fmt.Errorf("failed to determine start version for projection %s: %w", projectionName, err),
 		)
 	}
 
-	r.logger.Debug("Starting projection from last offset",
+	r.logger.Debug("Starting projection from start version",
 		slog.String("projection", projectionName),
-		slog.Any("last_version", lastVersion),
+		slog.Any("start_version", startVersion),
 		slog.Int("batch_size", r.batchSize),
 	)
 
 	totalApplied := 0
 	var lastProcessed synckit.Version
-	currentAfter := lastVersion
+	currentAfter := startVersion
 
 	for {
 		// Load the next batch of events


### PR DESCRIPTION
## 🔧 Problem Solved

This PR addresses a critical footgun in the projection system where users need to manually handle `nil` offset returns from `OffsetStore.Get()` when a projection runs for the first time. Without this fix, projection runners can crash with nil pointer errors on initial runs.

## 🛠️ Implementation

### Key Changes
- **Added `getStartVersion()` helper method** to gracefully handle nil offset returns
- **Refactored `ApplySince()` method** to use the new helper instead of direct offset handling
- **Uses `EventStore.ParseVersion("")` to get zero version** when no offset exists

### Design Benefits
- ✅ **Robustness**: Handles documented nil returns gracefully
- ✅ **User Experience**: Projection runners "just work" without requiring boilerplate
- ✅ **Interface Stability**: No breaking changes to existing contracts
- ✅ **Type Safety**: Uses the event store's own version parsing logic
- ✅ **Backward Compatibility**: Works with all existing EventStore implementations

## 🧪 Testing

- ✅ All projection tests pass
- ✅ No regressions detected in broader test suite
- ✅ Edge cases properly handled

## 📚 Technical Details

The solution follows the recommended Option 1 design pattern:

```go
func (r *runner) getStartVersion(ctx context.Context) (synckit.Version, error) {
    offset, err := r.offsets.Get(ctx, r.projectorName())
    if err != nil {
        return nil, err
    }
    
    if offset != nil {
        return offset, nil
    }
    
    // No stored offset - start from beginning
    // Use store's ParseVersion with empty string to get zero version
    zeroVersion, err := r.store.ParseVersion(ctx, "")
    if err != nil {
        return nil, fmt.Errorf("failed to create zero version for projection start: %w", err)
    }
    
    return zeroVersion, nil
}
```

This elegant solution eliminates the common integration footgun and ensures projection runners provide a "pit of success" experience for users.

## 🎯 Impact

- **Eliminates nil pointer crashes** on first projection run
- **Improves developer experience** by removing manual nil handling requirement
- **Maintains full backward compatibility** with existing code
- **Follows established design patterns** in the go-sync-kit ecosystem
