### PR TITLE
dev: local tooling (Taskfile, hooks), data race fix, and Postgres test opt-in

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab
+indent_size = 4

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,76 @@
+version: '3'
+
+vars:
+  FUZZ_TIME: 10 # seconds
+
+tasks:
+  # Default: quick sanity checks
+  default:
+    desc: Vet + unit tests
+    cmds:
+      - task: vet
+      - task: test
+
+  fmt:
+    desc: Format Go code
+    cmds:
+      - go fmt ./...
+
+  vet:
+    desc: Static checks
+    cmds:
+      - go vet ./...
+
+  test:
+    desc: Unit tests (no cache)
+    cmds:
+      - go test ./... -count=1
+
+  test-no-pg:
+    desc: Run tests excluding storage/postgres (no local Postgres needed)
+    cmds:
+      - cmd: pwsh -NoProfile -File scripts/test-no-pg.ps1
+        platforms: [windows]
+      - cmd: sh -lc 'pkgs=$(go list ./... | grep -v "storage/postgres\(\$\|/\)" ); if [ -n "$pkgs" ]; then echo "$pkgs" | xargs go test -count=1; else echo "No packages to test"; fi'
+        platforms: [linux, darwin]
+
+  race:
+    desc: Unit tests with race detector
+    cmds:
+      - go test ./... -race -count=1
+
+  race-no-pg:
+    desc: Run race tests excluding storage/postgres (no local Postgres needed)
+    cmds:
+      - cmd: pwsh -NoProfile -File scripts/race-no-pg.ps1
+        platforms: [windows]
+      - cmd: sh -lc 'pkgs=$(go list ./... | grep -v "storage/postgres\(\$\|/\)" ); if [ -n "$pkgs" ]; then echo "$pkgs" | xargs go test -race -count=1; else echo "No packages to test"; fi'
+        platforms: [linux, darwin]
+
+  cover:
+    desc: Coverage summary
+    cmds:
+      - go test ./... -coverprofile=coverage.out -covermode=atomic -count=1
+      - go tool cover -func=coverage.out
+
+  bench:
+    desc: Run benchmarks
+    cmds:
+      - 'go test ./... -run "^$" -bench . -benchmem -count=1'
+
+  fuzz:
+    desc: Run fuzzers briefly
+    cmds:
+      - 'go test ./... -run "^$" -fuzz . -fuzztime {{.FUZZ_TIME}}s'
+
+  tidy:
+    desc: Ensure go.mod/go.sum are tidy (fails if tidy changed files)
+    cmds:
+      - go mod tidy
+    # Ensure no changes to go.mod/go.sum after tidy
+      - git diff --exit-code -- go.mod go.sum
+
+  plan-reminder:
+    desc: Gentle reminder to update *IMPLEMENTATION_PLAN after commits
+    cmds:
+      - echo Remember to update *IMPLEMENTATION_PLAN

--- a/cursor/fuzz_test.go
+++ b/cursor/fuzz_test.go
@@ -14,7 +14,7 @@ func FuzzUnmarshalWire(f *testing.F) {
 	f.Add([]byte(`{"kind":"string","data":"test"}`))
 	f.Add([]byte(`{"kind":"integer","data":0}`))
 	f.Add([]byte(`{"kind":"integer","data":18446744073709551615}`)) // max uint64
-	
+
 	// Add some edge cases
 	f.Add([]byte(`{}`))
 	f.Add([]byte(`{"kind":"","data":null}`))
@@ -22,7 +22,7 @@ func FuzzUnmarshalWire(f *testing.F) {
 	f.Add([]byte(`{"kind":"integer","data":-1}`))
 	f.Add([]byte(`{"kind":"integer","data":"not a number"}`))
 	f.Add([]byte(`{"kind":"bytes","data":"invalid base64!!!"}`))
-	
+
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Test that UnmarshalWire doesn't panic on arbitrary input
 		defer func() {
@@ -30,7 +30,7 @@ func FuzzUnmarshalWire(f *testing.F) {
 				t.Errorf("UnmarshalWire panicked on input %q: %v", data, r)
 			}
 		}()
-		
+
 		// First check if it's valid JSON at all
 		var raw json.RawMessage
 		if json.Unmarshal(data, &raw) != nil {
@@ -41,7 +41,7 @@ func FuzzUnmarshalWire(f *testing.F) {
 			}
 			return
 		}
-		
+
 		// Try to unmarshal into WireCursor
 		var wireCursor WireCursor
 		err := json.Unmarshal(data, &wireCursor)
@@ -49,44 +49,44 @@ func FuzzUnmarshalWire(f *testing.F) {
 			// If JSON unmarshaling fails, that's acceptable
 			return
 		}
-		
+
 		// Now test UnmarshalWire
 		cursor, err := UnmarshalWire(&wireCursor)
-		
+
 		// The function should either return a valid cursor or an error
 		// It should never panic
 		if err == nil && cursor == nil {
 			t.Errorf("UnmarshalWire returned nil cursor with no error for input: %q", data)
 		}
-		
+
 		// If we got a cursor back, it should implement the Cursor interface properly
 		if cursor != nil {
 			// Test that Kind() doesn't panic
 			_ = cursor.Kind()
-			
+
 			// If it's an IntegerCursor, test the Version interface methods
 			if ic, ok := cursor.(IntegerCursor); ok {
 				// Test that String() doesn't panic
 				_ = ic.String()
-				
+
 				// Test that IsZero() doesn't panic
 				_ = ic.IsZero()
-				
+
 				// Test that Compare doesn't panic with itself
 				result := ic.Compare(ic)
 				if result != 0 {
 					t.Errorf("IntegerCursor should be equal to itself, got comparison result: %d", result)
 				}
 			}
-			
+
 			// If it's a VectorCursor, test the Version interface methods
 			if vc, ok := cursor.(VectorCursor); ok {
 				// Test that String() doesn't panic
 				_ = vc.String()
-				
+
 				// Test that IsZero() doesn't panic
 				_ = vc.IsZero()
-				
+
 				// Test that Compare doesn't panic with itself
 				result := vc.Compare(vc)
 				if result != 0 {
@@ -104,45 +104,45 @@ func FuzzMarshalWire(f *testing.F) {
 	f.Add(uint64(1))
 	f.Add(uint64(100))
 	f.Add(uint64(18446744073709551615)) // max uint64
-	
+
 	f.Fuzz(func(t *testing.T, seq uint64) {
 		// Create an IntegerCursor
 		originalCursor := IntegerCursor{Seq: seq}
-		
+
 		// Marshal it
 		wireCursor, err := MarshalWire(originalCursor)
 		if err != nil {
 			t.Fatalf("MarshalWire failed: %v", err)
 		}
-		
+
 		if wireCursor == nil {
 			t.Fatal("MarshalWire returned nil WireCursor")
 		}
-		
+
 		// Unmarshal it
 		restoredCursor, err := UnmarshalWire(wireCursor)
 		if err != nil {
 			t.Fatalf("UnmarshalWire failed: %v", err)
 		}
-		
+
 		// Cast to IntegerCursor for comparison
 		restoredIC, ok := restoredCursor.(IntegerCursor)
 		if !ok {
 			t.Fatalf("Expected IntegerCursor, got %T", restoredCursor)
 		}
-		
+
 		// They should be equal
 		if originalCursor.Compare(restoredIC) != 0 {
-			t.Errorf("Round-trip failed: original %v != restored %v", 
+			t.Errorf("Round-trip failed: original %v != restored %v",
 				originalCursor, restoredIC)
 		}
-		
+
 		// String representations should be equal
 		if originalCursor.String() != restoredIC.String() {
 			t.Errorf("String representation mismatch: original %q != restored %q",
 				originalCursor.String(), restoredIC.String())
 		}
-		
+
 		// IsZero should match
 		if originalCursor.IsZero() != restoredIC.IsZero() {
 			t.Errorf("IsZero mismatch: original %v != restored %v",
@@ -157,14 +157,14 @@ func FuzzWireCursorJSON(f *testing.F) {
 	f.Add(`{"kind":"integer","data":42}`)
 	f.Add(`{"kind":"bytes","data":"aGVsbG8="}`)
 	f.Add(`{"kind":"string","data":"hello world"}`)
-	
+
 	f.Fuzz(func(t *testing.T, jsonData string) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("JSON operations panicked on input %q: %v", jsonData, r)
 			}
 		}()
-		
+
 		// Try to unmarshal the fuzzed JSON
 		var wireCursor WireCursor
 		err := json.Unmarshal([]byte(jsonData), &wireCursor)
@@ -172,14 +172,14 @@ func FuzzWireCursorJSON(f *testing.F) {
 			// Invalid JSON is acceptable
 			return
 		}
-		
+
 		// If unmarshaling succeeded, try to marshal it back
 		marshalledData, err := json.Marshal(&wireCursor)
 		if err != nil {
 			t.Errorf("Failed to marshal WireCursor back to JSON: %v", err)
 			return
 		}
-		
+
 		// Try to unmarshal the marshalled data again
 		var wireCursor2 WireCursor
 		err = json.Unmarshal(marshalledData, &wireCursor2)
@@ -187,13 +187,13 @@ func FuzzWireCursorJSON(f *testing.F) {
 			t.Errorf("Failed to unmarshal re-marshalled WireCursor: %v", err)
 			return
 		}
-		
+
 		// The Kind should be preserved
 		if wireCursor.Kind != wireCursor2.Kind {
-			t.Errorf("Kind mismatch after round-trip: %q != %q", 
+			t.Errorf("Kind mismatch after round-trip: %q != %q",
 				wireCursor.Kind, wireCursor2.Kind)
 		}
-		
+
 		// The Data should be equivalent (though might be formatted differently)
 		if wireCursor.Kind == "integer" || wireCursor.Kind == "string" {
 			// For these types, the data should be exactly equal
@@ -213,20 +213,20 @@ func FuzzCursorComparison(f *testing.F) {
 	f.Add(uint64(100), uint64(50))
 	f.Add(uint64(18446744073709551615), uint64(0))
 	f.Add(uint64(18446744073709551615), uint64(18446744073709551615))
-	
+
 	f.Fuzz(func(t *testing.T, seq1, seq2 uint64) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("Cursor comparison panicked: %v", r)
 			}
 		}()
-		
+
 		cursor1 := IntegerCursor{Seq: seq1}
 		cursor2 := IntegerCursor{Seq: seq2}
-		
+
 		// Test Compare method
 		result := cursor1.Compare(cursor2)
-		
+
 		// Verify comparison properties
 		if seq1 == seq2 && result != 0 {
 			t.Errorf("Equal cursors should compare to 0, got %d", result)
@@ -237,7 +237,7 @@ func FuzzCursorComparison(f *testing.F) {
 		if seq1 > seq2 && result <= 0 {
 			t.Errorf("cursor1 > cursor2 should return positive, got %d", result)
 		}
-		
+
 		// Test symmetry: Compare(a, b) should be opposite of Compare(b, a)
 		reverseResult := cursor2.Compare(cursor1)
 		if result != 0 && reverseResult != 0 {
@@ -246,13 +246,13 @@ func FuzzCursorComparison(f *testing.F) {
 					seq1, seq2, result, seq2, seq1, reverseResult)
 			}
 		}
-		
+
 		// Test reflexivity: cursor should equal itself
 		selfResult := cursor1.Compare(cursor1)
 		if selfResult != 0 {
 			t.Errorf("Cursor should be equal to itself, got %d", selfResult)
 		}
-		
+
 		// Test that IsZero is consistent
 		if seq1 == 0 && !cursor1.IsZero() {
 			t.Error("Cursor with Seq=0 should be zero")
@@ -266,27 +266,27 @@ func FuzzCursorComparison(f *testing.F) {
 // FuzzIntegerCursorEdgeCases fuzzes IntegerCursor with edge cases
 func FuzzIntegerCursorEdgeCases(f *testing.F) {
 	// Add some edge cases for uint64
-	f.Add(uint64(0))                        // minimum
-	f.Add(uint64(1))                        // minimum non-zero
-	f.Add(uint64(18446744073709551615))     // maximum uint64
-	f.Add(uint64(9223372036854775807))      // max int64
-	f.Add(uint64(9223372036854775808))      // max int64 + 1
-	
+	f.Add(uint64(0))                    // minimum
+	f.Add(uint64(1))                    // minimum non-zero
+	f.Add(uint64(18446744073709551615)) // maximum uint64
+	f.Add(uint64(9223372036854775807))  // max int64
+	f.Add(uint64(9223372036854775808))  // max int64 + 1
+
 	f.Fuzz(func(t *testing.T, seq uint64) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("IntegerCursor operations panicked with seq=%d: %v", seq, r)
 			}
 		}()
-		
+
 		cursor := IntegerCursor{Seq: seq}
-		
+
 		// Test String method
 		str := cursor.String()
 		if str == "" {
 			t.Error("String() should not return empty string")
 		}
-		
+
 		// Test IsZero method
 		isZero := cursor.IsZero()
 		if seq == 0 && !isZero {
@@ -295,27 +295,27 @@ func FuzzIntegerCursorEdgeCases(f *testing.F) {
 		if seq != 0 && isZero {
 			t.Errorf("Seq=%d should not be zero", seq)
 		}
-		
+
 		// Test that we can marshal and unmarshal
 		wireCursor, err := MarshalWire(cursor)
 		if err != nil {
 			t.Errorf("MarshalWire failed for seq=%d: %v", seq, err)
 			return
 		}
-		
+
 		restoredCursor, err := UnmarshalWire(wireCursor)
 		if err != nil {
 			t.Errorf("UnmarshalWire failed for seq=%d: %v", seq, err)
 			return
 		}
-		
+
 		// Cast to IntegerCursor for comparison
 		restoredIC, ok := restoredCursor.(IntegerCursor)
 		if !ok {
 			t.Errorf("Expected IntegerCursor, got %T", restoredCursor)
 			return
 		}
-		
+
 		if cursor.Compare(restoredIC) != 0 {
 			t.Errorf("Round-trip failed for seq=%d", seq)
 		}

--- a/cursor/wire_test.go
+++ b/cursor/wire_test.go
@@ -3,9 +3,9 @@ package cursor
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
-	"math"
 )
 
 // TestWireFormat_IntegerCursor_KnownFormats tests that integer cursors marshal to expected JSON
@@ -113,7 +113,7 @@ func TestWireFormat_VectorCursor_KnownFormats(t *testing.T) {
 		{
 			name: "realistic node names",
 			cursor: VectorCursor{Counters: map[string]uint64{
-				"web-server-1": 150,
+				"web-server-1":  150,
 				"worker-node-2": 89,
 			}},
 			// We'll validate this one via round-trip since key order varies
@@ -183,7 +183,7 @@ func TestWireFormat_VectorCursor_KnownFormats(t *testing.T) {
 			}
 
 			if len(restoredVC.Counters) != len(tt.cursor.Counters) {
-				t.Errorf("Round-trip counters length mismatch: got %d, want %d", 
+				t.Errorf("Round-trip counters length mismatch: got %d, want %d",
 					len(restoredVC.Counters), len(tt.cursor.Counters))
 			}
 
@@ -201,7 +201,7 @@ func TestWireFormat_BackwardCompatibility(t *testing.T) {
 	InitDefaultCodecs()
 
 	tests := []struct {
-		name          string
+		name           string
 		historicalJSON string
 		expectedType   string
 		validate       func(t *testing.T, cursor Cursor)
@@ -435,12 +435,12 @@ func TestWireFormat_RoundTripConsistency(t *testing.T) {
 		{
 			name: "vector multiple nodes",
 			cursor: VectorCursor{Counters: map[string]uint64{
-				"web-1":     150,
-				"web-2":     143,
-				"worker-1":  89,
-				"worker-2":  91,
-				"db-1":      200,
-				"cache-1":   175,
+				"web-1":    150,
+				"web-2":    143,
+				"worker-1": 89,
+				"worker-2": 91,
+				"db-1":     200,
+				"cache-1":  175,
 			}},
 		},
 		{
@@ -509,7 +509,7 @@ func TestWireFormat_RoundTripConsistency(t *testing.T) {
 					t.Fatalf("Type mismatch after round-trip: expected VectorCursor, got %T", restored)
 				}
 				if len(restored.Counters) != len(original.Counters) {
-					t.Errorf("Counters length mismatch: got %d, want %d", 
+					t.Errorf("Counters length mismatch: got %d, want %d",
 						len(restored.Counters), len(original.Counters))
 				}
 				for k, v := range original.Counters {
@@ -562,7 +562,7 @@ func TestWireFormat_JSONCompliance(t *testing.T) {
 			}
 
 			if len(decoded.Data) != len(wire.Data) {
-				t.Errorf("Data length mismatch after JSON round-trip: got %d, want %d", 
+				t.Errorf("Data length mismatch after JSON round-trip: got %d, want %d",
 					len(decoded.Data), len(wire.Data))
 			}
 
@@ -573,7 +573,7 @@ func TestWireFormat_JSONCompliance(t *testing.T) {
 			}
 
 			if restoredCursor.Kind() != cursor.Kind() {
-				t.Errorf("Cursor kind mismatch after JSON round-trip: got %s, want %s", 
+				t.Errorf("Cursor kind mismatch after JSON round-trip: got %s, want %s",
 					restoredCursor.Kind(), cursor.Kind())
 			}
 		})
@@ -585,8 +585,8 @@ func TestWireFormat_EdgeCases(t *testing.T) {
 	InitDefaultCodecs()
 
 	tests := []struct {
-		name    string
-		test    func(t *testing.T)
+		name string
+		test func(t *testing.T)
 	}{
 		{
 			name: "nil wire cursor validation",

--- a/errors/propagation_test.go
+++ b/errors/propagation_test.go
@@ -24,29 +24,29 @@ type MockEvent struct {
 	metadata    map[string]interface{}
 }
 
-func (e *MockEvent) ID() string                            { return e.id }
-func (e *MockEvent) Type() string                          { return e.eventType }
-func (e *MockEvent) AggregateID() string                   { return e.aggregateID }
-func (e *MockEvent) Data() interface{}                     { return e.data }
-func (e *MockEvent) Metadata() map[string]interface{}     { return e.metadata }
+func (e *MockEvent) ID() string                       { return e.id }
+func (e *MockEvent) Type() string                     { return e.eventType }
+func (e *MockEvent) AggregateID() string              { return e.aggregateID }
+func (e *MockEvent) Data() interface{}                { return e.data }
+func (e *MockEvent) Metadata() map[string]interface{} { return e.metadata }
 
 // TestWrapOpComponent tests the WrapOpComponent helper function
 func TestWrapOpComponent(t *testing.T) {
 	tests := []struct {
-		name        string
-		err         error
-		op          string
-		component   string
-		expectedOp  errors.Operation
+		name         string
+		err          error
+		op           string
+		component    string
+		expectedOp   errors.Operation
 		expectedComp string
-		nilError    bool
+		nilError     bool
 	}{
 		{
-			name:         "nil error returns nil",
-			err:          nil,
-			op:           "test.Operation",
-			component:    "test/component",
-			nilError:     true,
+			name:      "nil error returns nil",
+			err:       nil,
+			op:        "test.Operation",
+			component: "test/component",
+			nilError:  true,
 		},
 		{
 			name:         "basic error wrapping",
@@ -69,7 +69,7 @@ func TestWrapOpComponent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := errors.WrapOpComponent(tt.err, tt.op, tt.component)
-			
+
 			if tt.nilError {
 				if result != nil {
 					t.Errorf("Expected nil error, got %v", result)
@@ -192,14 +192,14 @@ func TestSQLiteStoreErrorPropagation(t *testing.T) {
 func TestHTTPTransportErrorPropagation(t *testing.T) {
 	// Create transport with invalid base URL to trigger errors
 	transport := httptransport.NewTransport("invalid://url", nil, nil, nil)
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	// Create a mock event that will cause marshal errors
 	event := &MockEvent{
 		id:          "test-event",
-		eventType:   "TestEvent", 
+		eventType:   "TestEvent",
 		aggregateID: "test-aggregate",
 		data:        make(chan int), // channels can't be marshaled to JSON
 		metadata:    map[string]interface{}{"test": "metadata"},

--- a/examples/intermediate/03-events-and-storage/main.go
+++ b/examples/intermediate/03-events-and-storage/main.go
@@ -1,5 +1,5 @@
 // Example 3: Event Creation and Storage
-// 
+//
 // This example demonstrates:
 // - Creating custom events with proper Event interface
 // - Storing events locally with versioning
@@ -22,12 +22,12 @@ import (
 
 // UserEvent represents a custom event type
 type UserEvent struct {
-	EventID     string                 `json:"id"`
-	EventType   string                 `json:"event_type"`
-	UserID      string                 `json:"user_id"`
-	Username    string                 `json:"username"`
-	Email       string                 `json:"email,omitempty"`
-	Timestamp   time.Time              `json:"timestamp"`
+	EventID       string                 `json:"id"`
+	EventType     string                 `json:"event_type"`
+	UserID        string                 `json:"user_id"`
+	Username      string                 `json:"username"`
+	Email         string                 `json:"email,omitempty"`
+	Timestamp     time.Time              `json:"timestamp"`
 	EventMetadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
@@ -81,7 +81,7 @@ func main() {
 		{
 			EventID:   "evt-001",
 			EventType: "user.registered",
-			UserID:    "user-001", 
+			UserID:    "user-001",
 			Username:  "alice",
 			Email:     "alice@example.com",
 			Timestamp: time.Now(),
@@ -91,7 +91,7 @@ func main() {
 			},
 		},
 		{
-			EventID:   "evt-002", 
+			EventID:   "evt-002",
 			EventType: "user.updated",
 			UserID:    "user-001",
 			Username:  "alice_updated",
@@ -108,14 +108,14 @@ func main() {
 	fmt.Println("\n💾 Storing events:")
 	for i, event := range events {
 		version := cursor.IntegerCursor{Seq: uint64(i + 1)}
-		
+
 		err := store.Store(ctx, event, version)
 		if err != nil {
 			log.Printf("Failed to store event %d: %v", i+1, err)
 			continue
 		}
 
-		fmt.Printf("  ✅ Stored %s (v%d) - %s\n", 
+		fmt.Printf("  ✅ Stored %s (v%d) - %s\n",
 			event.EventType, i+1, event.Username)
 
 		// Show event data
@@ -126,7 +126,7 @@ func main() {
 
 	// Retrieve events from storage
 	fmt.Println("📚 Retrieving events from storage...")
-	
+
 	// Load all events since version 0
 	zeroVersion := cursor.IntegerCursor{Seq: 0}
 	storedEvents, err := store.Load(ctx, zeroVersion)
@@ -140,8 +140,8 @@ func main() {
 			ev.Version.String(),
 			ev.Event.Type(),
 			ev.Event.AggregateID())
-		
-		// Show stored event data 
+
+		// Show stored event data
 		evData, _ := json.MarshalIndent(ev.Event.Data(), "     ", "  ")
 		fmt.Printf("     📄 Data: %s\n", string(evData))
 		fmt.Println()
@@ -164,12 +164,12 @@ func main() {
 
 	fmt.Printf("✅ Sync completed!\n")
 	fmt.Printf("   Duration: %v\n", result.Duration)
-	fmt.Printf("   Events pushed: %d\n", result.EventsPushed) 
+	fmt.Printf("   Events pushed: %d\n", result.EventsPushed)
 	fmt.Printf("   Events pulled: %d\n", result.EventsPulled)
 
 	fmt.Println("\n🎉 Example completed! Check 'events-simple.db' to see stored events.")
 	fmt.Println("\n💡 Key Takeaways:")
-	fmt.Println("   • Custom events implement the Event interface") 
+	fmt.Println("   • Custom events implement the Event interface")
 	fmt.Println("   • Events are stored with sequential version numbers")
 	fmt.Println("   • You can retrieve all events or query by version range")
 	fmt.Println("   • Sync operations work with local-only (null transport) setup")

--- a/examples/intermediate/04-conflict-resolution/main.go
+++ b/examples/intermediate/04-conflict-resolution/main.go
@@ -1,5 +1,5 @@
 // Example 4: Conflict Resolution Demo
-// 
+//
 // This example demonstrates:
 // - Different conflict resolution strategies (LWW, FWW, Additive Merge)
 // - Simulating concurrent modifications from multiple clients
@@ -22,15 +22,15 @@ import (
 
 // DocumentEvent represents a document editing event
 type DocumentEvent struct {
-	EventID     string    `json:"id"`
-	EventType   string    `json:"event_type"`
-	DocumentID  string    `json:"document_id"`
-	Content     string    `json:"content"`
-	AuthorID    string    `json:"author_id"`
-	AuthorName  string    `json:"author_name"`
-	EditTime    time.Time `json:"edit_time"`
-	ClientID    string    `json:"client_id"`
-	VersionNum  int       `json:"version_num"`
+	EventID    string    `json:"id"`
+	EventType  string    `json:"event_type"`
+	DocumentID string    `json:"document_id"`
+	Content    string    `json:"content"`
+	AuthorID   string    `json:"author_id"`
+	AuthorName string    `json:"author_name"`
+	EditTime   time.Time `json:"edit_time"`
+	ClientID   string    `json:"client_id"`
+	VersionNum int       `json:"version_num"`
 }
 
 // Implement the Event interface
@@ -67,17 +67,17 @@ type CustomConflictResolver struct {
 
 func (r *CustomConflictResolver) Resolve(ctx context.Context, conflict synckit.Conflict) (synckit.ResolvedConflict, error) {
 	fmt.Printf("🔧 Custom resolver '%s' handling conflict for aggregate: %s\n", r.name, conflict.AggregateID)
-	
+
 	// For this example, we'll implement a "latest author wins" strategy
 	// The Conflict struct has Local and Remote single events, not slices
-	
+
 	var selectedEvent synckit.EventWithVersion
 	var reason string
-	
+
 	// Get the local and remote events
 	localDocEvent, localOk := conflict.Local.Event.Data().(*DocumentEvent)
 	remoteDocEvent, remoteOk := conflict.Remote.Event.Data().(*DocumentEvent)
-	
+
 	if !localOk || !remoteOk {
 		// Fallback to remote if we can't parse
 		selectedEvent = conflict.Remote
@@ -86,7 +86,7 @@ func (r *CustomConflictResolver) Resolve(ctx context.Context, conflict synckit.C
 		// Compare edit times and select the latest
 		if remoteDocEvent.EditTime.After(localDocEvent.EditTime) {
 			selectedEvent = conflict.Remote
-			reason = fmt.Sprintf("Selected remote event from %s (%v) over local from %s (%v)", 
+			reason = fmt.Sprintf("Selected remote event from %s (%v) over local from %s (%v)",
 				remoteDocEvent.AuthorName, remoteDocEvent.EditTime.Format("15:04:05"),
 				localDocEvent.AuthorName, localDocEvent.EditTime.Format("15:04:05"))
 		} else {
@@ -117,7 +117,7 @@ func main() {
 	}
 	defer storeA.Close()
 
-	// Client B store  
+	// Client B store
 	storeB, err := sqlite.NewWithDataSource("client-b.db")
 	if err != nil {
 		log.Fatalf("Failed to create Client B store: %v", err)
@@ -156,7 +156,7 @@ func main() {
 
 		mgrB, err := synckit.NewManager(
 			synckit.WithStore(storeB),
-			synckit.WithNullTransport(), 
+			synckit.WithNullTransport(),
 			strategy.option,
 		)
 		if err != nil {
@@ -165,7 +165,7 @@ func main() {
 
 		// Simulate conflicting edits to the same document
 		baseTime := time.Now()
-		
+
 		// Client A edits the document first
 		eventA := &DocumentEvent{
 			EventID:    fmt.Sprintf("edit-a-%d", i),
@@ -208,14 +208,14 @@ func main() {
 		}
 
 		fmt.Println("\n📅 Conflict Scenario:")
-		fmt.Printf("  🅰️  Client A: '%s' by %s at %s\n", 
+		fmt.Printf("  🅰️  Client A: '%s' by %s at %s\n",
 			eventA.Content[:50]+"...", eventA.AuthorName, eventA.EditTime.Format("15:04:05"))
 		fmt.Printf("  🅱️  Client B: '%s' by %s at %s\n",
 			eventB.Content[:50]+"...", eventB.AuthorName, eventB.EditTime.Format("15:04:05"))
 
 		// Now simulate sync where conflicts need to be resolved
 		fmt.Println("\n🔄 Performing sync operations...")
-		
+
 		// Sync client A (this will work fine)
 		resultA, err := mgrA.Sync(ctx)
 		if err != nil {
@@ -236,16 +236,16 @@ func main() {
 
 		// Show what was resolved
 		fmt.Println("\n✅ Resolution Results:")
-		
+
 		// Load events from both stores to see final state
 		zeroVersion := cursor.IntegerCursor{Seq: 0}
-		
+
 		eventsA, err := storeA.LoadByAggregate(ctx, "shared-doc-001", zeroVersion)
 		if err == nil {
 			fmt.Printf("  📄 Client A final state (%d events):\n", len(eventsA))
 			for _, ev := range eventsA {
 				if docEvent, ok := ev.Event.Data().(*DocumentEvent); ok {
-					fmt.Printf("    📝 %s: '%s' by %s\n", 
+					fmt.Printf("    📝 %s: '%s' by %s\n",
 						ev.Version.String(), docEvent.Content[:40]+"...", docEvent.AuthorName)
 				}
 			}
@@ -268,7 +268,7 @@ func main() {
 		case "Last-Write-Wins":
 			fmt.Println("  • LWW selected Bob's edit (later timestamp)")
 		case "First-Write-Wins":
-			fmt.Println("  • FWW selected Alice's edit (encountered first)")  
+			fmt.Println("  • FWW selected Alice's edit (encountered first)")
 		case "Additive Merge":
 			fmt.Println("  • Additive merge combined both edits if possible")
 		case "Custom Resolver":

--- a/examples/intermediate/05-realtime-autosync/main.go
+++ b/examples/intermediate/05-realtime-autosync/main.go
@@ -1,5 +1,5 @@
 // Example 5: Real-time Auto Sync Demo
-// 
+//
 // This example demonstrates:
 // - Setting up automatic synchronization with timers
 // - Background sync operations that don't block the main thread
@@ -89,14 +89,14 @@ func NewAutoSyncManager(manager synckit.SyncManager, interval time.Duration) *Au
 
 func (a *AutoSyncManager) Start() {
 	fmt.Printf("🚀 Starting auto-sync with %v interval\n", a.interval)
-	
+
 	go func() {
 		ticker := time.NewTicker(a.interval)
 		defer ticker.Stop()
-		
+
 		// Initial sync
 		a.performSync()
-		
+
 		for {
 			select {
 			case <-a.ctx.Done():
@@ -111,17 +111,17 @@ func (a *AutoSyncManager) Start() {
 
 func (a *AutoSyncManager) performSync() {
 	fmt.Printf("\n🔄 Auto-sync triggered at %s\n", time.Now().Format("15:04:05"))
-	
+
 	result, err := a.manager.Sync(a.ctx)
 	a.syncCount++
 	a.lastSync = time.Now()
-	
+
 	if err != nil {
 		a.errorCount++
 		fmt.Printf("❌ Auto-sync failed: %v\n", err)
 		return
 	}
-	
+
 	fmt.Printf("✅ Auto-sync completed: %d pushed, %d pulled, %d conflicts resolved\n",
 		result.EventsPushed, result.EventsPulled, result.ConflictsResolved)
 }
@@ -147,7 +147,7 @@ func main() {
 	}
 	defer storeA.Close()
 
-	storeB, err := sqlite.NewWithDataSource("autosync-client-b.db") 
+	storeB, err := sqlite.NewWithDataSource("autosync-client-b.db")
 	if err != nil {
 		log.Fatalf("Failed to create store B: %v", err)
 	}
@@ -157,7 +157,7 @@ func main() {
 
 	// Create managers with different auto-sync intervals
 	fmt.Println("🔧 Creating sync managers...")
-	
+
 	managerA, err := synckit.NewManager(
 		synckit.WithStore(storeA),
 		synckit.WithNullTransport(),
@@ -187,7 +187,7 @@ func main() {
 	// Simulate creating tasks on different clients over time
 	go func() {
 		time.Sleep(1 * time.Second)
-		
+
 		for i := 0; i < 10; i++ {
 			// Create tasks alternating between clients
 			if i%2 == 0 {
@@ -205,7 +205,7 @@ func main() {
 					UpdatedAt:    time.Now(),
 					Priority:     "medium",
 				}
-				
+
 				version := cursor.IntegerCursor{Seq: uint64(100 + i)}
 				err := storeA.Store(ctx, task, version)
 				if err != nil {
@@ -228,7 +228,7 @@ func main() {
 					UpdatedAt:    time.Now(),
 					Priority:     "high",
 				}
-				
+
 				version := cursor.IntegerCursor{Seq: uint64(200 + i)}
 				err := storeB.Store(ctx, task, version)
 				if err != nil {
@@ -237,7 +237,7 @@ func main() {
 					fmt.Printf("📝 Client B created: '%s'\n", task.Title)
 				}
 			}
-			
+
 			time.Sleep(2 * time.Second)
 		}
 	}()
@@ -246,16 +246,16 @@ func main() {
 	go func() {
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
-		
+
 		for {
 			select {
 			case <-ticker.C:
 				fmt.Println("\n📊 Auto-Sync Statistics:")
-				
+
 				syncCountA, errorCountA, lastSyncA := autoSyncA.Stats()
 				fmt.Printf("  🅰️  Client A: %d syncs, %d errors, last sync: %s\n",
 					syncCountA, errorCountA, lastSyncA.Format("15:04:05"))
-					
+
 				syncCountB, errorCountB, lastSyncB := autoSyncB.Stats()
 				fmt.Printf("  🅱️  Client B: %d syncs, %d errors, last sync: %s\n",
 					syncCountB, errorCountB, lastSyncB.Format("15:04:05"))
@@ -283,23 +283,23 @@ func main() {
 	// Final statistics
 	time.Sleep(100 * time.Millisecond)
 	fmt.Println("\n📊 Final Auto-Sync Statistics:")
-	
+
 	syncCountA, errorCountA, lastSyncA := autoSyncA.Stats()
 	fmt.Printf("  🅰️  Client A: %d syncs, %d errors, last sync: %s\n",
 		syncCountA, errorCountA, lastSyncA.Format("15:04:05"))
-		
+
 	syncCountB, errorCountB, lastSyncB := autoSyncB.Stats()
 	fmt.Printf("  🅱️  Client B: %d syncs, %d errors, last sync: %s\n",
 		syncCountB, errorCountB, lastSyncB.Format("15:04:05"))
 
 	// Show final event counts
 	zeroVersion := cursor.IntegerCursor{Seq: 0}
-	
+
 	eventsA, err := storeA.Load(ctx, zeroVersion)
 	if err == nil {
 		fmt.Printf("  📄 Client A total events: %d\n", len(eventsA))
 	}
-	
+
 	eventsB, err := storeB.Load(ctx, zeroVersion)
 	if err == nil {
 		fmt.Printf("  📄 Client B total events: %d\n", len(eventsB))

--- a/examples/intermediate/06-custom-events-filters/main.go
+++ b/examples/intermediate/06-custom-events-filters/main.go
@@ -1,5 +1,5 @@
 // Example 6: Custom Events and Filters Demo
-// 
+//
 // This example demonstrates:
 // - Creating various custom event types for different domains
 // - Implementing event filtering to sync only specific event types
@@ -35,18 +35,18 @@ type BaseEvent struct {
 // UserEvent represents user management events
 type UserEvent struct {
 	BaseEvent
-	Username     string `json:"username"`
-	Email        string `json:"email"`
-	Role         string `json:"role"`
-	Action       string `json:"action"` // created, updated, deleted, login
-	Department   string `json:"department"`
-	IsActive     bool   `json:"is_active"`
+	Username   string `json:"username"`
+	Email      string `json:"email"`
+	Role       string `json:"role"`
+	Action     string `json:"action"` // created, updated, deleted, login
+	Department string `json:"department"`
+	IsActive   bool   `json:"is_active"`
 }
 
-func (e *UserEvent) ID() string                           { return e.EventID }
-func (e *UserEvent) Type() string                         { return e.EventType }
-func (e *UserEvent) AggregateID() string                  { return e.BaseEvent.AggregateID }
-func (e *UserEvent) Data() interface{}                    { return e }
+func (e *UserEvent) ID() string          { return e.EventID }
+func (e *UserEvent) Type() string        { return e.EventType }
+func (e *UserEvent) AggregateID() string { return e.BaseEvent.AggregateID }
+func (e *UserEvent) Data() interface{}   { return e }
 func (e *UserEvent) Metadata() map[string]interface{} {
 	meta := make(map[string]interface{})
 	meta["user_id"] = e.UserID
@@ -66,19 +66,19 @@ func (e *UserEvent) Metadata() map[string]interface{} {
 // ProductEvent represents e-commerce product events
 type ProductEvent struct {
 	BaseEvent
-	ProductName  string  `json:"product_name"`
-	Category     string  `json:"category"`
-	Price        float64 `json:"price"`
-	SKU          string  `json:"sku"`
-	Action       string  `json:"action"` // created, updated, price_changed, discontinued
-	StockLevel   int     `json:"stock_level"`
-	IsAvailable  bool    `json:"is_available"`
+	ProductName string  `json:"product_name"`
+	Category    string  `json:"category"`
+	Price       float64 `json:"price"`
+	SKU         string  `json:"sku"`
+	Action      string  `json:"action"` // created, updated, price_changed, discontinued
+	StockLevel  int     `json:"stock_level"`
+	IsAvailable bool    `json:"is_available"`
 }
 
-func (e *ProductEvent) ID() string                           { return e.EventID }
-func (e *ProductEvent) Type() string                         { return e.EventType }
-func (e *ProductEvent) AggregateID() string                  { return e.BaseEvent.AggregateID }
-func (e *ProductEvent) Data() interface{}                    { return e }
+func (e *ProductEvent) ID() string          { return e.EventID }
+func (e *ProductEvent) Type() string        { return e.EventType }
+func (e *ProductEvent) AggregateID() string { return e.BaseEvent.AggregateID }
+func (e *ProductEvent) Data() interface{}   { return e }
 func (e *ProductEvent) Metadata() map[string]interface{} {
 	meta := make(map[string]interface{})
 	meta["user_id"] = e.UserID
@@ -110,10 +110,10 @@ type OrderEvent struct {
 	Priority     string  `json:"priority"` // low, normal, high, urgent
 }
 
-func (e *OrderEvent) ID() string                           { return e.EventID }
-func (e *OrderEvent) Type() string                         { return e.EventType }
-func (e *OrderEvent) AggregateID() string                  { return e.BaseEvent.AggregateID }
-func (e *OrderEvent) Data() interface{}                    { return e }
+func (e *OrderEvent) ID() string          { return e.EventID }
+func (e *OrderEvent) Type() string        { return e.EventType }
+func (e *OrderEvent) AggregateID() string { return e.BaseEvent.AggregateID }
+func (e *OrderEvent) Data() interface{}   { return e }
 func (e *OrderEvent) Metadata() map[string]interface{} {
 	meta := make(map[string]interface{})
 	meta["user_id"] = e.UserID
@@ -161,7 +161,7 @@ func (f *EventFilters) HighPriorityEvents(event synckit.Event) bool {
 		}
 		return priorityStr == "high" || priorityStr == "urgent"
 	}
-	
+
 	// Also include user role changes and login events as high priority
 	if strings.HasPrefix(event.Type(), "user.") {
 		if action, exists := metadata["action"]; exists {
@@ -172,7 +172,7 @@ func (f *EventFilters) HighPriorityEvents(event synckit.Event) bool {
 			return actionStr == "login" || actionStr == "role_changed"
 		}
 	}
-	
+
 	return false
 }
 
@@ -219,7 +219,7 @@ func main() {
 
 	// Create store for the demo
 	fmt.Println("🏗️ Setting up event store...")
-	
+
 	store, err := sqlite.NewWithDataSource("filtered-events.db")
 	if err != nil {
 		log.Fatalf("Failed to create store: %v", err)
@@ -231,62 +231,62 @@ func main() {
 
 	// Create sample events of different types
 	fmt.Println("📝 Creating sample events of different types...")
-	
+
 	events := []synckit.Event{
 		// User events
 		&UserEvent{
-			BaseEvent:   BaseEvent{EventID: "user-1", EventType: "user.created", AggregateID: "user-001", Timestamp: time.Now().Add(-2*time.Hour), UserID: "admin", TenantID: "tenant-a"},
-			Username:    "alice",
-			Email:       "alice@company.com",
-			Role:        "admin",
-			Action:      "created",
-			Department:  "engineering",
-			IsActive:    true,
+			BaseEvent:  BaseEvent{EventID: "user-1", EventType: "user.created", AggregateID: "user-001", Timestamp: time.Now().Add(-2 * time.Hour), UserID: "admin", TenantID: "tenant-a"},
+			Username:   "alice",
+			Email:      "alice@company.com",
+			Role:       "admin",
+			Action:     "created",
+			Department: "engineering",
+			IsActive:   true,
 		},
 		&UserEvent{
-			BaseEvent:   BaseEvent{EventID: "user-2", EventType: "user.login", AggregateID: "user-001", Timestamp: time.Now().Add(-30*time.Minute), UserID: "alice", TenantID: "tenant-a"},
-			Username:    "alice",
-			Email:       "alice@company.com",
-			Role:        "admin",
-			Action:      "login",
-			Department:  "engineering",
-			IsActive:    true,
+			BaseEvent:  BaseEvent{EventID: "user-2", EventType: "user.login", AggregateID: "user-001", Timestamp: time.Now().Add(-30 * time.Minute), UserID: "alice", TenantID: "tenant-a"},
+			Username:   "alice",
+			Email:      "alice@company.com",
+			Role:       "admin",
+			Action:     "login",
+			Department: "engineering",
+			IsActive:   true,
 		},
 		&UserEvent{
-			BaseEvent:   BaseEvent{EventID: "user-3", EventType: "user.updated", AggregateID: "user-002", Timestamp: time.Now().Add(-1*time.Hour), UserID: "admin", TenantID: "tenant-b"},
-			Username:    "bob",
-			Email:       "bob@company.com",
-			Role:        "user",
-			Action:      "updated",
-			Department:  "sales",
-			IsActive:    true,
+			BaseEvent:  BaseEvent{EventID: "user-3", EventType: "user.updated", AggregateID: "user-002", Timestamp: time.Now().Add(-1 * time.Hour), UserID: "admin", TenantID: "tenant-b"},
+			Username:   "bob",
+			Email:      "bob@company.com",
+			Role:       "user",
+			Action:     "updated",
+			Department: "sales",
+			IsActive:   true,
 		},
-		
+
 		// Product events
 		&ProductEvent{
-			BaseEvent:    BaseEvent{EventID: "prod-1", EventType: "product.created", AggregateID: "prod-001", Timestamp: time.Now().Add(-3*time.Hour), UserID: "admin", TenantID: "tenant-a"},
-			ProductName:  "Wireless Headphones",
-			Category:     "electronics",
-			Price:        99.99,
-			SKU:          "WH-001",
-			Action:       "created",
-			StockLevel:   100,
-			IsAvailable:  true,
+			BaseEvent:   BaseEvent{EventID: "prod-1", EventType: "product.created", AggregateID: "prod-001", Timestamp: time.Now().Add(-3 * time.Hour), UserID: "admin", TenantID: "tenant-a"},
+			ProductName: "Wireless Headphones",
+			Category:    "electronics",
+			Price:       99.99,
+			SKU:         "WH-001",
+			Action:      "created",
+			StockLevel:  100,
+			IsAvailable: true,
 		},
 		&ProductEvent{
-			BaseEvent:    BaseEvent{EventID: "prod-2", EventType: "product.price_changed", AggregateID: "prod-001", Timestamp: time.Now().Add(-20*time.Minute), UserID: "manager", TenantID: "tenant-a"},
-			ProductName:  "Wireless Headphones",
-			Category:     "electronics",
-			Price:        89.99,
-			SKU:          "WH-001",
-			Action:       "price_changed",
-			StockLevel:   95,
-			IsAvailable:  true,
+			BaseEvent:   BaseEvent{EventID: "prod-2", EventType: "product.price_changed", AggregateID: "prod-001", Timestamp: time.Now().Add(-20 * time.Minute), UserID: "manager", TenantID: "tenant-a"},
+			ProductName: "Wireless Headphones",
+			Category:    "electronics",
+			Price:       89.99,
+			SKU:         "WH-001",
+			Action:      "price_changed",
+			StockLevel:  95,
+			IsAvailable: true,
 		},
-		
+
 		// Order events
 		&OrderEvent{
-			BaseEvent:    BaseEvent{EventID: "order-1", EventType: "order.created", AggregateID: "order-001", Timestamp: time.Now().Add(-45*time.Minute), UserID: "system", TenantID: "tenant-a", EventMetadata: map[string]string{"priority": "urgent"}},
+			BaseEvent:    BaseEvent{EventID: "order-1", EventType: "order.created", AggregateID: "order-001", Timestamp: time.Now().Add(-45 * time.Minute), UserID: "system", TenantID: "tenant-a", EventMetadata: map[string]string{"priority": "urgent"}},
 			OrderID:      "ORD-001",
 			CustomerID:   "cust-001",
 			TotalAmount:  299.99,
@@ -297,7 +297,7 @@ func main() {
 			Priority:     "urgent",
 		},
 		&OrderEvent{
-			BaseEvent:    BaseEvent{EventID: "order-2", EventType: "order.paid", AggregateID: "order-001", Timestamp: time.Now().Add(-15*time.Minute), UserID: "system", TenantID: "tenant-a", EventMetadata: map[string]string{"priority": "urgent"}},
+			BaseEvent:    BaseEvent{EventID: "order-2", EventType: "order.paid", AggregateID: "order-001", Timestamp: time.Now().Add(-15 * time.Minute), UserID: "system", TenantID: "tenant-a", EventMetadata: map[string]string{"priority": "urgent"}},
 			OrderID:      "ORD-001",
 			CustomerID:   "cust-001",
 			TotalAmount:  299.99,
@@ -308,7 +308,7 @@ func main() {
 			Priority:     "urgent",
 		},
 		&OrderEvent{
-			BaseEvent:    BaseEvent{EventID: "order-3", EventType: "order.created", AggregateID: "order-002", Timestamp: time.Now().Add(-2*time.Hour), UserID: "system", TenantID: "tenant-b", EventMetadata: map[string]string{"priority": "low"}},
+			BaseEvent:    BaseEvent{EventID: "order-3", EventType: "order.created", AggregateID: "order-002", Timestamp: time.Now().Add(-2 * time.Hour), UserID: "system", TenantID: "tenant-b", EventMetadata: map[string]string{"priority": "low"}},
 			OrderID:      "ORD-002",
 			CustomerID:   "cust-002",
 			TotalAmount:  49.99,
@@ -393,7 +393,7 @@ func main() {
 			continue
 		}
 		defer scenarioStore.Close()
-		
+
 		// Create a sync manager with the current filter
 		manager, err := synckit.NewManager(
 			synckit.WithStore(scenarioStore),
@@ -428,24 +428,24 @@ func main() {
 			if scenario.filter(eventWithVersion.Event) {
 				filteredCount++
 				metadata := eventWithVersion.Event.Metadata()
-				
+
 				switch e := eventWithVersion.Event.Data().(type) {
 				case *UserEvent:
-					fmt.Printf("  👤 %s: %s (%s) - %s [%s]\n", 
+					fmt.Printf("  👤 %s: %s (%s) - %s [%s]\n",
 						eventWithVersion.Event.Type(), e.Username, e.Role, e.Action, e.TenantID)
 				case *ProductEvent:
-					fmt.Printf("  📦 %s: %s ($%.2f) - %s [%s]\n", 
+					fmt.Printf("  📦 %s: %s ($%.2f) - %s [%s]\n",
 						eventWithVersion.Event.Type(), e.ProductName, e.Price, e.Action, e.TenantID)
 				case *OrderEvent:
-					fmt.Printf("  🛒 %s: %s ($%.2f) - %s (%s priority) [%s]\n", 
+					fmt.Printf("  🛒 %s: %s ($%.2f) - %s (%s priority) [%s]\n",
 						eventWithVersion.Event.Type(), e.OrderID, e.TotalAmount, e.Status, e.Priority, e.TenantID)
 				default:
-					fmt.Printf("  🔍 %s: %s [%v]\n", 
+					fmt.Printf("  🔍 %s: %s [%v]\n",
 						eventWithVersion.Event.Type(), eventWithVersion.Event.ID(), metadata["tenant_id"])
 				}
 			}
 		}
-		
+
 		fmt.Printf("\n📊 Filter Results: %d out of %d events match the filter (%.1f%%)\n",
 			filteredCount, len(allEvents), float64(filteredCount)/float64(len(allEvents))*100)
 

--- a/examples/intermediate/07-structured-logging/main.go
+++ b/examples/intermediate/07-structured-logging/main.go
@@ -34,8 +34,8 @@ func main() {
 	)
 
 	// Demonstrate operation logging with duration tracking
-	err := logging.LogOperation(ctx, 
-		logging.Operation("user-authentication"), 
+	err := logging.LogOperation(ctx,
+		logging.Operation("user-authentication"),
 		logging.Component("auth-service"),
 		func() error {
 			// Simulate some work
@@ -43,9 +43,9 @@ func main() {
 			return nil
 		},
 	)
-	
+
 	if err != nil {
-		logging.Error("Authentication operation failed", 
+		logging.Error("Authentication operation failed",
 			slog.String("error", err.Error()))
 	}
 
@@ -58,8 +58,8 @@ func main() {
 		Err:       fmt.Errorf("disk space insufficient"),
 		Retryable: true,
 		Metadata: map[string]interface{}{
-			"disk_usage": "95%",
-			"required_space": "100MB",
+			"disk_usage":      "95%",
+			"required_space":  "100MB",
 			"available_space": "10MB",
 		},
 	}
@@ -76,7 +76,7 @@ func main() {
 			slog.String("path", "/api/sync"),
 			slog.String("user_id", "user123"),
 		),
-		slog.Group("response", 
+		slog.Group("response",
 			slog.Int("status", 200),
 			slog.Duration("latency", 150*time.Millisecond),
 			slog.Int("body_size", 2048),
@@ -90,12 +90,12 @@ func main() {
 	// Demonstrate context-aware logging
 	ctx = context.WithValue(ctx, "request_id", "req-abc123")
 	ctx = context.WithValue(ctx, "trace_id", "trace-xyz789")
-	
-	contextLogger := logging.WithContext(ctx, 
+
+	contextLogger := logging.WithContext(ctx,
 		slog.String("user_id", "user456"),
 		slog.String("session_id", "sess-def456"),
 	)
-	
+
 	contextLogger.Info("Processing user request",
 		slog.String("action", "sync_data"),
 		slog.Int("items_to_sync", 25),
@@ -115,7 +115,7 @@ func main() {
 		slog.Duration("reset_in", 30*time.Second),
 	)
 
-	// Demonstrate custom log levels  
+	// Demonstrate custom log levels
 	logging.Trace("Detailed trace information",
 		slog.String("function", "processRequest"),
 		slog.Any("parameters", []string{"param1", "param2"}),
@@ -124,10 +124,10 @@ func main() {
 	// Demonstrate dynamic level changes
 	if os.Getenv("DEMO_DYNAMIC_LEVEL") == "true" {
 		logger, levelVar := logging.NewLoggerWithDynamicLevel(config)
-		
+
 		logger.Debug("This won't appear at INFO level")
 		logger.Info("This will appear")
-		
+
 		// Change to debug level at runtime
 		levelVar.SetFromString("debug")
 		logger.Debug("This will now appear after level change")

--- a/examples/intermediate/08-stateful-resolvers/main.go
+++ b/examples/intermediate/08-stateful-resolvers/main.go
@@ -25,25 +25,25 @@ import (
 
 // UserAccountEvent represents user account management events
 type UserAccountEvent struct {
-	EventID      string            `json:"id"`
-	EventType    string            `json:"event_type"`
-	UserID       string            `json:"user_id"`
-	AccountType  string            `json:"account_type"`
-	Email        string            `json:"email"`
-	DisplayName  string            `json:"display_name"`
-	Permissions  []string          `json:"permissions"`
-	LastActivity time.Time         `json:"last_activity"`
-	Priority     int               `json:"priority"`
+	EventID       string            `json:"id"`
+	EventType     string            `json:"event_type"`
+	UserID        string            `json:"user_id"`
+	AccountType   string            `json:"account_type"`
+	Email         string            `json:"email"`
+	DisplayName   string            `json:"display_name"`
+	Permissions   []string          `json:"permissions"`
+	LastActivity  time.Time         `json:"last_activity"`
+	Priority      int               `json:"priority"`
 	EventMetadata map[string]string `json:"metadata"`
-	ModifiedBy   string            `json:"modified_by"`
-	ModifiedAt   time.Time         `json:"modified_at"`
+	ModifiedBy    string            `json:"modified_by"`
+	ModifiedAt    time.Time         `json:"modified_at"`
 }
 
 // Implement the Event interface
-func (e *UserAccountEvent) ID() string             { return e.EventID }
-func (e *UserAccountEvent) Type() string           { return e.EventType }
-func (e *UserAccountEvent) AggregateID() string    { return e.UserID }
-func (e *UserAccountEvent) Data() interface{}      { return e }
+func (e *UserAccountEvent) ID() string          { return e.EventID }
+func (e *UserAccountEvent) Type() string        { return e.EventType }
+func (e *UserAccountEvent) AggregateID() string { return e.UserID }
+func (e *UserAccountEvent) Data() interface{}   { return e }
 
 func (e *UserAccountEvent) Metadata() map[string]interface{} {
 	return map[string]interface{}{
@@ -90,24 +90,24 @@ func (r *PriorityResolver) Resolve(ctx context.Context, conflict synckit.Conflic
 	if localPriority > remotePriority {
 		selectedEvent = conflict.Local
 		decision = "local_account_priority"
-		reasons = append(reasons, fmt.Sprintf("Local account type '%s' has higher priority than remote '%s'", 
+		reasons = append(reasons, fmt.Sprintf("Local account type '%s' has higher priority than remote '%s'",
 			localEvent.AccountType, remoteEvent.AccountType))
 	} else if remotePriority > localPriority {
 		selectedEvent = conflict.Remote
 		decision = "remote_account_priority"
-		reasons = append(reasons, fmt.Sprintf("Remote account type '%s' has higher priority than local '%s'", 
+		reasons = append(reasons, fmt.Sprintf("Remote account type '%s' has higher priority than local '%s'",
 			remoteEvent.AccountType, localEvent.AccountType))
 	} else {
 		// Same account type, check permissions count
 		if len(localEvent.Permissions) > len(remoteEvent.Permissions) {
 			selectedEvent = conflict.Local
 			decision = "local_permissions"
-			reasons = append(reasons, fmt.Sprintf("Local has more permissions (%d vs %d)", 
+			reasons = append(reasons, fmt.Sprintf("Local has more permissions (%d vs %d)",
 				len(localEvent.Permissions), len(remoteEvent.Permissions)))
 		} else if len(remoteEvent.Permissions) > len(localEvent.Permissions) {
 			selectedEvent = conflict.Remote
 			decision = "remote_permissions"
-			reasons = append(reasons, fmt.Sprintf("Remote has more permissions (%d vs %d)", 
+			reasons = append(reasons, fmt.Sprintf("Remote has more permissions (%d vs %d)",
 				len(remoteEvent.Permissions), len(localEvent.Permissions)))
 		} else {
 			// Fall back to timestamp
@@ -224,7 +224,7 @@ func (mt *MockTransport) Pull(ctx context.Context, since synckit.Version) ([]syn
 	if !ok {
 		sinceCursor = cursor.IntegerCursor{Seq: 0}
 	}
-	
+
 	var events []synckit.EventWithVersion
 	for _, event := range mt.remoteEvents {
 		if eventCursor, ok := event.Version.(cursor.IntegerCursor); ok {
@@ -268,9 +268,9 @@ func (mt *MockTransport) Subscribe(ctx context.Context, handler func([]synckit.E
 
 // Custom observability hooks for monitoring
 type MonitoringHooks struct {
-	stateTransitions   int
-	rulesEvaluated     int
-	workflowsCompleted int
+	stateTransitions    int
+	rulesEvaluated      int
+	workflowsCompleted  int
 	totalResolutionTime time.Duration
 }
 
@@ -309,7 +309,7 @@ func (h *MonitoringHooks) createObservabilityHooks() *statemachine.ConflictResol
 		},
 
 		OnMetricsRecorded: func(metrics *statemachine.ResolverPerformanceMetrics) {
-			fmt.Printf("  📊 Performance metrics updated: %d conflicts resolved, avg time: %v\n", 
+			fmt.Printf("  📊 Performance metrics updated: %d conflicts resolved, avg time: %v\n",
 				metrics.TotalConflictsResolved, metrics.AverageResolutionTime)
 		},
 	}
@@ -359,7 +359,7 @@ func main() {
 
 	// Create stateful dynamic resolver with comprehensive rules
 	dynamicResolver, err := synckit.NewDynamicResolver(
-		synckit.WithRule("admin_accounts", 
+		synckit.WithRule("admin_accounts",
 			synckit.And(
 				synckit.EventTypeIs("account.updated"),
 				synckit.MetadataEq("account_type", "admin"),
@@ -398,10 +398,10 @@ func main() {
 	// Create test conflicts
 	baseTime := time.Now()
 	timestamp := baseTime.Unix()
-	
+
 	// Create mock transport with remote conflicting events
 	mockTransport := NewMockTransport()
-	
+
 	// Add remote events that will conflict with local events
 	remoteStandardEvent := &UserAccountEvent{
 		EventID:      fmt.Sprintf("remote-standard-%d", timestamp),
@@ -409,15 +409,15 @@ func main() {
 		UserID:       "user-001", // Same user = conflict
 		AccountType:  "standard",
 		Email:        "john.doe@company.com", // Different email
-		DisplayName:  "John D.", // Different name
-		Permissions:  []string{"read"}, // Fewer permissions
+		DisplayName:  "John D.",              // Different name
+		Permissions:  []string{"read"},       // Fewer permissions
 		LastActivity: baseTime.Add(-2 * time.Hour),
 		Priority:     1,
 		ModifiedBy:   "user-001",
 		ModifiedAt:   baseTime.Add(-5 * time.Second), // Older
 	}
 	mockTransport.AddRemoteEvent(remoteStandardEvent, cursor.IntegerCursor{Seq: 1000})
-	
+
 	remotePremiumEvent := &UserAccountEvent{
 		EventID:      fmt.Sprintf("remote-premium-%d", timestamp+1),
 		EventType:    "account.updated",
@@ -432,7 +432,7 @@ func main() {
 		ModifiedAt:   baseTime.Add(15 * time.Second), // Newer
 	}
 	mockTransport.AddRemoteEvent(remotePremiumEvent, cursor.IntegerCursor{Seq: 1001})
-	
+
 	remoteAdminEvent := &UserAccountEvent{
 		EventID:      fmt.Sprintf("remote-admin-%d", timestamp+2),
 		EventType:    "account.updated",
@@ -443,13 +443,13 @@ func main() {
 		Permissions:  []string{"read", "write", "admin", "delete", "system", "super"},
 		LastActivity: baseTime.Add(-10 * time.Minute),
 		Priority:     3,
-		ModifiedBy:   "admin-001", // Different admin
+		ModifiedBy:   "admin-001",                    // Different admin
 		ModifiedAt:   baseTime.Add(25 * time.Second), // Even newer
 	}
 	mockTransport.AddRemoteEvent(remoteAdminEvent, cursor.IntegerCursor{Seq: 1002})
-	
+
 	fmt.Printf("  📡 Set up %d remote conflicting events\n", len(mockTransport.remoteEvents))
-	
+
 	// Create sync manager with mock transport
 	manager, err := synckit.NewManager(
 		synckit.WithStore(store),
@@ -459,7 +459,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create manager: %v", err)
 	}
-
 
 	// Standard user event
 	standardUserEvent := &UserAccountEvent{
@@ -534,7 +533,7 @@ func main() {
 	fmt.Println("\n🎛️ State Machine Status:")
 	currentState := statefulResolver.GetCurrentState()
 	fmt.Printf("  • Current State: %s\n", currentState.String())
-	
+
 	stateHistory := statefulResolver.GetStateHistory()
 	fmt.Printf("  • State History: %d transitions\n", len(stateHistory))
 
@@ -578,7 +577,7 @@ func main() {
 			AccountType:  []string{"standard", "premium", "admin"}[i],
 			Email:        fmt.Sprintf("user%d@example.com", i),
 			DisplayName:  fmt.Sprintf("User %d", i),
-		Permissions:  []string{"read", "write", "admin"}[:i+1],
+			Permissions:  []string{"read", "write", "admin"}[:i+1],
 			LastActivity: time.Now(),
 			Priority:     i + 1,
 			ModifiedBy:   fmt.Sprintf("user-%d", i),
@@ -613,7 +612,7 @@ func main() {
 	if finalMetrics != nil {
 		fmt.Printf("\n🏁 Final Performance Metrics:\n")
 		fmt.Printf("  • Total Operations: %d\n", finalMetrics.TotalConflictsResolved)
-		fmt.Printf("  • Success Rate: %.2f%%\n", 
+		fmt.Printf("  • Success Rate: %.2f%%\n",
 			float64(finalMetrics.AutoResolvedCount)/float64(finalMetrics.TotalConflictsResolved)*100)
 		fmt.Printf("  • Average Processing Time: %v\n", finalMetrics.AverageResolutionTime)
 	}
@@ -632,17 +631,17 @@ func main() {
 
 // StateObserver for real-time monitoring
 type StateObserver struct {
-	name string
+	name            string
 	transitionCount int
 }
 
 func (so *StateObserver) OnTransition(transition statemachine.StateTransition[statemachine.ConflictResolutionState]) {
 	so.transitionCount++
-	fmt.Printf("  🔄 [%s] Observed transition #%d: %s → %s\n", 
+	fmt.Printf("  🔄 [%s] Observed transition #%d: %s → %s\n",
 		so.name, so.transitionCount, transition.From.String(), transition.To.String())
 }
 
 func (so *StateObserver) OnTransitionFailed(from, to statemachine.ConflictResolutionState, err error, metadata map[string]interface{}) {
-	fmt.Printf("  ❌ [%s] Transition failed: %s → %s (error: %v)\n", 
+	fmt.Printf("  ❌ [%s] Transition failed: %s → %s (error: %v)\n",
 		so.name, from.String(), to.String(), err)
 }

--- a/examples/intermediate/09-advanced-observability/main.go
+++ b/examples/intermediate/09-advanced-observability/main.go
@@ -42,16 +42,16 @@ type SystemMetrics struct {
 
 // TransactionEvent represents business transaction events
 type TransactionEvent struct {
-	EventID      string            `json:"id"`
-	EventType    string            `json:"event_type"`
-	TransactionID string           `json:"transaction_id"`
-	Amount       float64           `json:"amount"`
-	Currency     string            `json:"currency"`
-	AccountID    string            `json:"account_id"`
-	CustomerID   string            `json:"customer_id"`
-	Timestamp    time.Time         `json:"timestamp"`
-	Status       string            `json:"status"`
-	EventMetadata     map[string]string `json:"metadata"`
+	EventID       string            `json:"id"`
+	EventType     string            `json:"event_type"`
+	TransactionID string            `json:"transaction_id"`
+	Amount        float64           `json:"amount"`
+	Currency      string            `json:"currency"`
+	AccountID     string            `json:"account_id"`
+	CustomerID    string            `json:"customer_id"`
+	Timestamp     time.Time         `json:"timestamp"`
+	Status        string            `json:"status"`
+	EventMetadata map[string]string `json:"metadata"`
 }
 
 // Implement the Event interface
@@ -86,8 +86,8 @@ type MetricsCollector struct {
 
 func NewMetricsCollector() *MetricsCollector {
 	return &MetricsCollector{
-		startTime:     time.Now(),
-		dashboardData: make(map[string]interface{}),
+		startTime:      time.Now(),
+		dashboardData:  make(map[string]interface{}),
 		operationTimes: make([]time.Duration, 0, 1000),
 	}
 }
@@ -156,14 +156,14 @@ func (mc *MetricsCollector) estimateCPUUsage() float64 {
 
 // Alert represents a monitoring alert
 type Alert struct {
-	ID          string                 `json:"id"`
-	Type        string                 `json:"type"`
-	Severity    string                 `json:"severity"`
-	Message     string                 `json:"message"`
-	Timestamp   time.Time              `json:"timestamp"`
-	Metadata    map[string]interface{} `json:"metadata"`
-	Resolved    bool                   `json:"resolved"`
-	ResolvedAt  *time.Time             `json:"resolved_at,omitempty"`
+	ID         string                 `json:"id"`
+	Type       string                 `json:"type"`
+	Severity   string                 `json:"severity"`
+	Message    string                 `json:"message"`
+	Timestamp  time.Time              `json:"timestamp"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Resolved   bool                   `json:"resolved"`
+	ResolvedAt *time.Time             `json:"resolved_at,omitempty"`
 }
 
 func (mc *MetricsCollector) checkAlertConditions() {
@@ -171,7 +171,7 @@ func (mc *MetricsCollector) checkAlertConditions() {
 
 	// High error rate alert
 	if metrics.ErrorRate > 5.0 {
-		mc.triggerAlert("high_error_rate", "WARNING", 
+		mc.triggerAlert("high_error_rate", "WARNING",
 			fmt.Sprintf("Error rate is %.2f%%, exceeding threshold of 5%%", metrics.ErrorRate),
 			map[string]interface{}{"error_rate": metrics.ErrorRate})
 	}
@@ -246,7 +246,7 @@ func NewDashboard(mc *MetricsCollector, updateInterval time.Duration) *Dashboard
 
 func (d *Dashboard) Start() {
 	fmt.Println("📈 Starting real-time dashboard...")
-	
+
 	go func() {
 		ticker := time.NewTicker(d.updateInterval)
 		defer ticker.Stop()
@@ -264,7 +264,7 @@ func (d *Dashboard) Start() {
 
 func (d *Dashboard) updateDashboard() {
 	metrics := d.metricsCollector.GetCurrentMetrics()
-	
+
 	fmt.Printf("\r📊 Live Dashboard | Ops: %d | Conflicts: %d | Latency: %.1fms | CPU: %.1f%% | Mem: %.1fMB | Errors: %.1f%% | Throughput: %.1f ops/s",
 		metrics.SyncOperationsCount,
 		metrics.ConflictsResolved,
@@ -287,10 +287,10 @@ type HealthChecker struct {
 }
 
 type HealthCheck struct {
-	Name        string    `json:"name"`
-	Status      string    `json:"status"`
-	LastChecked time.Time `json:"last_checked"`
-	Message     string    `json:"message"`
+	Name        string        `json:"name"`
+	Status      string        `json:"status"`
+	LastChecked time.Time     `json:"last_checked"`
+	Message     string        `json:"message"`
 	Duration    time.Duration `json:"duration"`
 }
 
@@ -306,7 +306,7 @@ func (hc *HealthChecker) RegisterCheck(name string, checkFunc func() (bool, stri
 			start := time.Now()
 			healthy, message := checkFunc()
 			duration := time.Since(start)
-			
+
 			status := "HEALTHY"
 			if !healthy {
 				status = "UNHEALTHY"
@@ -337,10 +337,10 @@ type ObservabilityResolver struct {
 
 func (r *ObservabilityResolver) Resolve(ctx context.Context, conflict synckit.Conflict) (synckit.ResolvedConflict, error) {
 	start := time.Now()
-	
+
 	// Simulate some processing time for demonstration
 	time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
-	
+
 	// Simple LWW resolution with monitoring
 	result := synckit.ResolvedConflict{
 		ResolvedEvents: []synckit.EventWithVersion{conflict.Remote},
@@ -349,7 +349,7 @@ func (r *ObservabilityResolver) Resolve(ctx context.Context, conflict synckit.Co
 	}
 
 	duration := time.Since(start)
-	
+
 	// Simulate occasional errors for demonstration
 	hasError := rand.Float64() < 0.02 // 2% error rate
 	if hasError {
@@ -366,7 +366,7 @@ func main() {
 
 	// Setup monitoring infrastructure
 	fmt.Println("🏗️ Setting up comprehensive monitoring infrastructure...")
-	
+
 	store, err := sqlite.NewWithDataSource("observability-demo.db")
 	if err != nil {
 		log.Fatalf("Failed to create store: %v", err)
@@ -375,15 +375,15 @@ func main() {
 
 	// Create metrics collector
 	metricsCollector := NewMetricsCollector()
-	
+
 	// Create health checker
 	healthChecker := NewHealthChecker()
-	
+
 	// Register health checks
 	healthChecker.RegisterCheck("database", func() (bool, string) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		
+
 		// Simple health check - try to query the database
 		_, err := store.Load(ctx, cursor.IntegerCursor{Seq: 0})
 		if err != nil {
@@ -396,7 +396,7 @@ func main() {
 		var memStats runtime.MemStats
 		runtime.ReadMemStats(&memStats)
 		memUsageMB := float64(memStats.Alloc) / 1024 / 1024
-		
+
 		if memUsageMB > 1024 { // 1GB threshold
 			return false, fmt.Sprintf("High memory usage: %.2fMB", memUsageMB)
 		}
@@ -545,7 +545,7 @@ func main() {
 		if check.Status == "UNHEALTHY" {
 			status = "❌"
 		}
-		fmt.Printf("  %s %s: %s (checked: %v ago)\n", 
+		fmt.Printf("  %s %s: %s (checked: %v ago)\n",
 			status, name, check.Message, time.Since(check.LastChecked).Round(time.Second))
 	}
 
@@ -592,8 +592,8 @@ func main() {
 	resolverMetrics := statefulResolver.GetPerformanceMetrics()
 	if resolverMetrics != nil {
 		fmt.Printf("  • Resolver Operations: %d\n", resolverMetrics.TotalConflictsResolved)
-		fmt.Printf("  • Auto-resolved: %d (%.1f%%)\n", 
-			resolverMetrics.AutoResolvedCount, 
+		fmt.Printf("  • Auto-resolved: %d (%.1f%%)\n",
+			resolverMetrics.AutoResolvedCount,
 			float64(resolverMetrics.AutoResolvedCount)/float64(resolverMetrics.TotalConflictsResolved)*100)
 		fmt.Printf("  • Resolver Avg Time: %v\n", resolverMetrics.AverageResolutionTime)
 	}

--- a/examples/intermediate/10-state-machine-enhancements/main.go
+++ b/examples/intermediate/10-state-machine-enhancements/main.go
@@ -128,7 +128,7 @@ func visualizationDemo() {
 	// Perform some transitions to show current state highlighting
 	fmt.Println("\n🔄 Performing state transitions:")
 	transitions := []SyncState{SyncInitializing, SyncPulling, SyncResolvingConflicts}
-	
+
 	for _, state := range transitions {
 		if err := sm.Transition(state); err != nil {
 			fmt.Printf("❌ Failed to transition to %s: %v\n", state, err)
@@ -140,7 +140,7 @@ func visualizationDemo() {
 	// Export DOT representation
 	fmt.Println("\n📊 Generating DOT representation for visualization:")
 	dotContent := sm.ExportDOT()
-	
+
 	// Save to file for visualization
 	dotFile := "state_machine_diagram.dot"
 	if err := os.WriteFile(dotFile, []byte(dotContent), 0644); err != nil {
@@ -159,11 +159,11 @@ func visualizationDemo() {
 	if len(lines) < previewLines {
 		previewLines = len(lines)
 	}
-	
+
 	for i := 0; i < previewLines; i++ {
 		fmt.Printf("  %s\n", lines[i])
 	}
-	
+
 	if len(lines) > previewLines {
 		fmt.Printf("  ... (%d more lines)\n", len(lines)-previewLines)
 	}
@@ -196,7 +196,7 @@ func persistenceDemo() {
 	// Enable persistence with auto-save
 	persistenceConfig := statemachine.DefaultPersistenceConfig()
 	persistenceConfig.AutoSave = true
-	
+
 	fmt.Printf("📦 Enabling persistence for machine ID: %s\n", machineID)
 	if err := sm.EnablePersistence(persistence, machineID, persistenceConfig); err != nil {
 		fmt.Printf("❌ Failed to enable persistence: %v\n", err)
@@ -223,7 +223,7 @@ func persistenceDemo() {
 			fmt.Printf("    ❌ Transition failed: %v\n", err)
 			continue
 		}
-		
+
 		// Small delay to simulate work
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -251,7 +251,7 @@ func persistenceDemo() {
 
 	// Enable persistence - this should load the saved state
 	fmt.Printf("🔄 Restoring state for machine ID: %s\n", machineID)
-	
+
 	if err := newSM.EnablePersistence(persistence, machineID, persistenceConfig); err != nil {
 		fmt.Printf("❌ Failed to restore persistence: %v\n", err)
 		return
@@ -309,8 +309,8 @@ func timeoutDemo() {
 
 	// Set specific timeouts for different states
 	timeouts := map[SyncState]time.Duration{
-		SyncPulling: 1 * time.Second,  // Very short for demo
-		SyncPushing: 3 * time.Second,  // Slightly longer
+		SyncPulling: 1 * time.Second, // Very short for demo
+		SyncPushing: 3 * time.Second, // Slightly longer
 	}
 	timeoutHandler.SetTimeouts(timeouts)
 
@@ -333,10 +333,10 @@ func timeoutDemo() {
 
 	// Start with normal transitions
 	fmt.Println("\n🔄 Starting sync process with timeout monitoring:")
-	
+
 	fmt.Printf("  ➡️  Transitioning to: %s\n", SyncInitializing)
 	sm.Transition(SyncInitializing)
-	
+
 	fmt.Printf("  ➡️  Transitioning to: %s (will timeout in %v)\n", SyncPulling, timeouts[SyncPulling])
 	sm.Transition(SyncPulling)
 
@@ -349,12 +349,12 @@ func timeoutDemo() {
 
 	if currentState == SyncTimeout {
 		fmt.Println("  ✅ SUCCESS: Timeout handling worked correctly!")
-		
+
 		// Transition from timeout to recovery
 		fmt.Printf("  🔄 Recovering from timeout...\n")
 		sm.Transition(SyncFailed)
 		fmt.Printf("  ➡️  Transitioned to recovery state: %s\n", sm.Current())
-		
+
 		// Reset to idle
 		sm.Transition(SyncIdle)
 		fmt.Printf("  ➡️  Reset to: %s\n", sm.Current())
@@ -373,11 +373,11 @@ func timeoutDemo() {
 
 	// Demonstrate successful operation within timeout
 	fmt.Println("\n✅ Demonstrating successful operation within timeout limits:")
-	
+
 	sm.Transition(SyncInitializing)
 	sm.Transition(SyncPushing) // This has a 3-second timeout
 	fmt.Printf("  ➡️  In %s state (timeout in %v)\n", SyncPushing, timeouts[SyncPushing])
-	
+
 	// Complete within timeout
 	time.Sleep(1 * time.Second)
 	sm.Transition(SyncCompleted)
@@ -420,7 +420,7 @@ func integrationDemo() {
 	timeoutConfig := statemachine.DefaultTimeoutConfig(SyncTimeout)
 	timeoutConfig.DefaultTimeout = 5 * time.Second
 	timeoutHandler := statemachine.NewTimeoutHandler(sm, timeoutConfig)
-	
+
 	timeoutHandler.SetTimeouts(map[SyncState]time.Duration{
 		SyncPulling:            3 * time.Second,
 		SyncPushing:            4 * time.Second,
@@ -439,10 +439,10 @@ func integrationDemo() {
 
 	// 3. Run a complete sync workflow
 	fmt.Println("\n🚀 Running complete enhanced sync workflow:")
-	
+
 	workflow := []struct {
-		state SyncState
-		delay time.Duration
+		state       SyncState
+		delay       time.Duration
 		description string
 	}{
 		{SyncInitializing, 200 * time.Millisecond, "Initialize sync"},
@@ -458,7 +458,7 @@ func integrationDemo() {
 			fmt.Printf("    ❌ Transition failed: %v\n", err)
 			continue
 		}
-		
+
 		// Simulate work with delay
 		time.Sleep(step.delay)
 	}
@@ -468,7 +468,7 @@ func integrationDemo() {
 	// 4. Generate visualization
 	fmt.Println("\n📊 Generating final state machine visualization...")
 	dotContent := sm.ExportDOT()
-	
+
 	visualFile := "enhanced_sync_machine.dot"
 	if err := os.WriteFile(visualFile, []byte(dotContent), 0644); err == nil {
 		fmt.Printf("✅ Enhanced state machine diagram saved as: %s\n", visualFile)
@@ -477,14 +477,14 @@ func integrationDemo() {
 	// 5. Show comprehensive metrics
 	fmt.Println("\n📈 Final Enhancement Summary:")
 	fmt.Printf("  🎨 Visualization: State diagram exported (%d lines)\n", len(strings.Split(dotContent, "\n")))
-	
+
 	if machines, err := persistence.ListMachines(context.Background()); err == nil {
 		fmt.Printf("  💾 Persistence: %d machines persisted\n", len(machines))
 	}
-	
+
 	finalMetrics := timeoutMetrics.GetMetrics()
 	fmt.Printf("  ⏰ Timeouts: %d total timeouts handled\n", finalMetrics.TotalTimeouts)
-	
+
 	fmt.Printf("  📊 State History: %d transitions recorded\n", len(sm.History()))
 
 	fmt.Println("\n🎉 All enhancements successfully demonstrated!")

--- a/examples/quickstart/local-only/main.go
+++ b/examples/quickstart/local-only/main.go
@@ -27,12 +27,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("init: %v", err)
 	}
-	
+
 	result, err := mgr.Sync(context.Background())
 	if err != nil {
 		log.Fatalf("sync: %v", err)
 	}
-	
+
 	log.Printf("Local sync completed successfully! Events: %d, Duration: %v\n",
 		result.EventsPushed+result.EventsPulled, result.Duration)
 }

--- a/examples/server-projection-hooks/main.go
+++ b/examples/server-projection-hooks/main.go
@@ -40,7 +40,7 @@ func (p *UserCountProjector) Name() string {
 
 func (p *UserCountProjector) Apply(ctx context.Context, events []synckit.EventWithVersion) error {
 	p.logger.Info("Applying events to user count projection", slog.Int("event_count", len(events)))
-	
+
 	// Create read model table if it doesn't exist
 	_, err := p.db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS user_stats (
@@ -52,7 +52,7 @@ func (p *UserCountProjector) Apply(ctx context.Context, events []synckit.EventWi
 	if err != nil {
 		return fmt.Errorf("failed to create user_stats table: %w", err)
 	}
-	
+
 	// Initialize stats if not exists
 	_, err = p.db.ExecContext(ctx, `
 		INSERT OR IGNORE INTO user_stats (id, user_count) VALUES (1, 0)
@@ -60,12 +60,12 @@ func (p *UserCountProjector) Apply(ctx context.Context, events []synckit.EventWi
 	if err != nil {
 		return fmt.Errorf("failed to initialize user_stats: %w", err)
 	}
-	
+
 	for _, ev := range events {
 		// Example: increment counter for UserCreated events
 		eventType := ev.Event.Type()
 		p.logger.Debug("Processing event", slog.String("type", eventType), slog.String("id", ev.Event.ID()))
-		
+
 		if eventType == "UserCreated" {
 			_, err := p.db.ExecContext(ctx, `
 				UPDATE user_stats 
@@ -90,7 +90,7 @@ func (p *UserCountProjector) Apply(ctx context.Context, events []synckit.EventWi
 			p.logger.Info("Decremented user count")
 		}
 	}
-	
+
 	return nil
 }
 
@@ -106,22 +106,22 @@ func (p *UserCountProjector) getUserCount(ctx context.Context) (int, error) {
 
 func main() {
 	logger := logging.Default().Logger
-	
+
 	logger.Info("Starting server with projection hooks example")
-	
+
 	// Create event store (SQLite)
 	store, err := sqlite.NewWithDataSource("server.db")
 	if err != nil {
 		log.Fatalf("Failed to create event store: %v", err)
 	}
-	
-	// Create separate SQLite database for read models  
+
+	// Create separate SQLite database for read models
 	readModelDB, err := sql.Open("sqlite3", "server_read_models.db")
 	if err != nil {
 		log.Fatalf("Failed to create read model database: %v", err)
 	}
 	defer readModelDB.Close()
-	
+
 	// Create BadgerDB-based offset store for projection state
 	offsetConfig := badger.DefaultConfig("projection_offsets")
 	offsetStore, err := badger.NewOffsetStore(offsetConfig, store.ParseVersion)
@@ -129,16 +129,16 @@ func main() {
 		log.Fatalf("Failed to create offset store: %v", err)
 	}
 	defer offsetStore.Close()
-	
+
 	// Create projector
 	projector := NewUserCountProjector(readModelDB, logger)
-	
+
 	// Create projection runner
 	runner := projection.NewRunner(store, offsetStore, projector,
 		projection.WithBatchSize(50),
 		projection.WithLogger(logger),
 	)
-	
+
 	// Create sync hooks
 	hooks := &httptransport.SyncHooks{
 		AfterCommit: func(ctx context.Context, committed []synckit.EventWithVersion) {
@@ -158,14 +158,14 @@ func main() {
 			logger.Debug("BeforePull hook called", slog.String("since_version", since.String()))
 		},
 	}
-	
+
 	// Create HTTP handler with hooks
 	handler := httptransport.NewSyncHandlerWithHooks(store, logger, nil, nil, hooks)
-	
+
 	// Create HTTP server
 	mux := http.NewServeMux()
 	mux.Handle("/sync/", handler)
-	
+
 	// Add a simple endpoint to query the read model
 	mux.HandleFunc("/stats/users", func(w http.ResponseWriter, r *http.Request) {
 		count, err := projector.getUserCount(r.Context())
@@ -174,25 +174,25 @@ func main() {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
-		
+
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"user_count": %d}`, count)
 	})
-	
+
 	// Add a simple health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `{"status": "healthy", "hooks_enabled": true}`)
 	})
-	
+
 	logger.Info("Server starting on :8080")
 	logger.Info("Endpoints:")
 	logger.Info("  POST /sync/push - Push events (triggers AfterCommit hook)")
 	logger.Info("  GET  /sync/pull?since=<version> - Pull events (triggers BeforePull hook)")
 	logger.Info("  GET  /stats/users - Get current user count from read model")
 	logger.Info("  GET  /health - Health check")
-	
+
 	if err := http.ListenAndServe(":8080", mux); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+echo "[pre-commit] gofmt check..."
+unformatted="$(gofmt -l . || true)"
+if [ -n "$unformatted" ]; then
+  echo "Files need gofmt:"
+  echo "$unformatted"
+  echo "Run: go fmt ./..."
+  exit 1
+fi
+
+echo "[pre-commit] go vet..."
+go vet ./...
+
+echo "[pre-commit] go test..."
+go test ./... -count=1
+
+# Reminder to update IMPLEMENTATION_PLAN (non-blocking)
+if ! git diff --cached --name-only | grep -E '(^|/).*IMPLEMENTATION_PLAN' >/dev/null 2>&1; then
+  echo "[pre-commit] Reminder: update *IMPLEMENTATION_PLAN (not blocking)."
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+echo "[pre-push] go test -race..."
+go test ./... -race -count=1

--- a/internal/integration-tests/verify_conflict_resolution.go
+++ b/internal/integration-tests/verify_conflict_resolution.go
@@ -19,18 +19,18 @@ type TestEvent struct {
 	data        interface{}
 }
 
-func (e *TestEvent) ID() string                         { return e.id }
-func (e *TestEvent) Type() string                       { return e.eventType }
-func (e *TestEvent) AggregateID() string                { return e.aggregateID }
-func (e *TestEvent) Data() interface{}                  { return e.data }
-func (e *TestEvent) Metadata() map[string]interface{}   { return nil }
+func (e *TestEvent) ID() string                       { return e.id }
+func (e *TestEvent) Type() string                     { return e.eventType }
+func (e *TestEvent) AggregateID() string              { return e.aggregateID }
+func (e *TestEvent) Data() interface{}                { return e.data }
+func (e *TestEvent) Metadata() map[string]interface{} { return nil }
 
 // Simple test version
 type TestVersion struct {
 	version string
 }
 
-func (v *TestVersion) String() string                    { return v.version }
+func (v *TestVersion) String() string { return v.version }
 func (v *TestVersion) Compare(other types.Version) int {
 	if other == nil {
 		return 1
@@ -101,26 +101,26 @@ func (m *MockTransport) Close() error {
 
 func main() {
 	fmt.Println("=== Conflict Resolution Integration Verification ===")
-	
+
 	// Create logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	
+
 	// Test 1: Default DynamicResolver creation
 	fmt.Println("\n1. Testing default DynamicResolver creation...")
-	
+
 	store := &MockStore{}
 	transport := &MockTransport{}
 	opts := &synckit.SyncOptions{
 		BatchSize: 10,
 	}
-	
+
 	sm := synckit.NewSyncManager(store, transport, opts, logger)
 	_ = sm // Use the variable to avoid unused error
 	fmt.Println("✅ SyncManager created successfully")
-	
+
 	// Test 2: Custom DynamicResolver
 	fmt.Println("\n2. Testing custom DynamicResolver...")
-	
+
 	resolver, err := synckit.NewDynamicResolver(
 		synckit.WithEventTypeRule("user_rule", "UserUpdated", &dynres.LastWriteWinsResolver{}),
 		synckit.WithFallback(&dynres.LastWriteWinsResolver{}),
@@ -131,10 +131,10 @@ func main() {
 		return
 	}
 	fmt.Println("✅ Custom DynamicResolver created successfully")
-	
+
 	// Test 3: Conflict resolution
 	fmt.Println("\n3. Testing conflict resolution...")
-	
+
 	conflict := dynres.Conflict{
 		EventType:   "UserUpdated",
 		AggregateID: "user-123",
@@ -142,19 +142,19 @@ func main() {
 		Remote:      types.EventWithVersion{Event: &TestEvent{id: "2", eventType: "UserUpdated", aggregateID: "user-123"}, Version: &TestVersion{version: "v2"}},
 		Metadata:    make(map[string]any),
 	}
-	
+
 	ctx := context.Background()
 	resolved, err := resolver.Resolve(ctx, conflict)
 	if err != nil {
 		fmt.Printf("❌ Failed to resolve conflict: %v\n", err)
 		return
 	}
-	
+
 	fmt.Printf("✅ Conflict resolved successfully with decision: %s\n", resolved.Decision)
 	fmt.Printf("   Resolved events count: %d\n", len(resolved.ResolvedEvents))
-	
+
 	fmt.Println("\n🎉 Conflict Resolution Integration Verification PASSED!")
 	fmt.Println("   - Default resolver injection: ✅")
-	fmt.Println("   - Custom resolver creation: ✅") 
+	fmt.Println("   - Custom resolver creation: ✅")
 	fmt.Println("   - Conflict resolution flow: ✅")
 }

--- a/logging/config.go
+++ b/logging/config.go
@@ -169,7 +169,7 @@ func (d *DynamicLevelVar) SetFromString(level string) bool {
 // NewLoggerWithDynamicLevel creates a logger with dynamic level support
 func NewLoggerWithDynamicLevel(config Config) (*Logger, *DynamicLevelVar) {
 	levelVar := NewDynamicLevelVar(slog.LevelInfo)
-	
+
 	opts := &slog.HandlerOptions{
 		Level:     levelVar.LevelVar,
 		AddSource: config.AddSource,

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -64,7 +64,7 @@ func (e SyncErrorValuer) LogValue() slog.Value {
 		slog.Bool("retryable", e.Retryable),
 		slog.String("error", e.Err.Error()),
 	}
-	
+
 	// Add metadata if present
 	if e.Metadata != nil {
 		metadataAttrs := make([]slog.Attr, 0, len(e.Metadata))
@@ -73,7 +73,7 @@ func (e SyncErrorValuer) LogValue() slog.Value {
 		}
 		attrs = append(attrs, slog.Any("metadata", slog.GroupValue(metadataAttrs...)))
 	}
-	
+
 	return slog.GroupValue(attrs...)
 }
 
@@ -136,36 +136,36 @@ func (l *Logger) WithComponent(component Component) *Logger {
 func (l *Logger) WithContext(ctx context.Context, attrs ...slog.Attr) *Logger {
 	// Extract common context values
 	contextAttrs := make([]any, 0, len(attrs)+2)
-	
+
 	// Add request ID if present
 	if reqID := ctx.Value("request_id"); reqID != nil {
 		contextAttrs = append(contextAttrs, slog.String("request_id", fmt.Sprintf("%v", reqID)))
 	}
-	
+
 	// Add trace ID if present
 	if traceID := ctx.Value("trace_id"); traceID != nil {
 		contextAttrs = append(contextAttrs, slog.String("trace_id", fmt.Sprintf("%v", traceID)))
 	}
-	
+
 	// Convert attrs to []any
 	for _, attr := range attrs {
 		contextAttrs = append(contextAttrs, attr)
 	}
-	
+
 	return &Logger{Logger: l.With(contextAttrs...)}
 }
 
 // LogError logs an error with stack trace information and structured attributes
 func (l *Logger) LogError(ctx context.Context, err error, msg string, attrs ...slog.Attr) {
 	allAttrs := make([]any, 0, len(attrs)+3)
-	
+
 	// Add error information
 	if syncErr, ok := err.(*errors.SyncError); ok {
 		allAttrs = append(allAttrs, slog.Any("sync_error", SyncErrorValuer{SyncError: syncErr}))
 	} else {
 		allAttrs = append(allAttrs, slog.String("error", err.Error()))
 	}
-	
+
 	// Add stack trace information
 	pc, file, line, ok := runtime.Caller(1)
 	if ok {
@@ -178,12 +178,12 @@ func (l *Logger) LogError(ctx context.Context, err error, msg string, attrs ...s
 			),
 		)
 	}
-	
+
 	// Convert attrs to []any
 	for _, attr := range attrs {
 		allAttrs = append(allAttrs, attr)
 	}
-	
+
 	l.ErrorContext(ctx, msg, allAttrs...)
 }
 
@@ -191,14 +191,14 @@ func (l *Logger) LogError(ctx context.Context, err error, msg string, attrs ...s
 func (l *Logger) LogOperation(ctx context.Context, op Operation, component Component, fn func() error) error {
 	start := time.Now()
 	opLogger := l.WithOperation(op).WithComponent(component)
-	
+
 	opLogger.InfoContext(ctx, "operation started",
 		slog.Time("start_time", start),
 	)
-	
+
 	err := fn()
 	duration := time.Since(start)
-	
+
 	if err != nil {
 		opLogger.LogError(ctx, err, "operation failed",
 			slog.Duration("duration", duration),
@@ -206,12 +206,12 @@ func (l *Logger) LogOperation(ctx context.Context, op Operation, component Compo
 		)
 		return err
 	}
-	
+
 	opLogger.InfoContext(ctx, "operation completed",
 		slog.Duration("duration", duration),
 		slog.Bool("success", true),
 	)
-	
+
 	return nil
 }
 

--- a/observability/health/checker.go
+++ b/observability/health/checker.go
@@ -112,7 +112,7 @@ func (h *HealthChecker) AddCheck(checkType CheckType, check HealthCheck) {
 	if h.checks[component] == nil {
 		h.checks[component] = make(map[CheckType][]HealthCheck)
 	}
-	
+
 	h.checks[component][checkType] = append(h.checks[component][checkType], check)
 }
 
@@ -151,11 +151,11 @@ func (h *HealthChecker) CheckStartup(ctx context.Context) OverallResult {
 // CheckAll performs all health checks and returns detailed results.
 func (h *HealthChecker) CheckAll(ctx context.Context) map[CheckType]OverallResult {
 	results := make(map[CheckType]OverallResult)
-	
+
 	results[CheckTypeLiveness] = h.CheckLiveness(ctx)
 	results[CheckTypeReadiness] = h.CheckReadiness(ctx)
 	results[CheckTypeStartup] = h.CheckStartup(ctx)
-	
+
 	return results
 }
 
@@ -192,7 +192,7 @@ type Summary struct {
 // runChecks executes all checks of a specific type.
 func (h *HealthChecker) runChecks(ctx context.Context, checkType CheckType) OverallResult {
 	start := time.Now()
-	
+
 	// Create timeout context
 	timeoutCtx, cancel := context.WithTimeout(ctx, h.config.Timeout)
 	defer cancel()
@@ -210,7 +210,7 @@ func (h *HealthChecker) runChecks(ctx context.Context, checkType CheckType) Over
 			for _, check := range checks {
 				result := h.executeCheck(timeoutCtx, check)
 				results[fmt.Sprintf("%s.%s", component, check.Name())] = result
-				
+
 				summary.Total++
 				switch result.Status {
 				case StatusUp:
@@ -257,7 +257,7 @@ func (h *HealthChecker) runChecks(ctx context.Context, checkType CheckType) Over
 // executeCheck runs a single health check with proper error handling.
 func (h *HealthChecker) executeCheck(ctx context.Context, check HealthCheck) CheckResult {
 	start := time.Now()
-	
+
 	// Recover from panics in health checks
 	defer func() {
 		if r := recover(); r != nil {
@@ -267,16 +267,16 @@ func (h *HealthChecker) executeCheck(ctx context.Context, check HealthCheck) Che
 
 	// Execute the check
 	result := check.Check(ctx)
-	
+
 	// Calculate the duration of this check
 	duration := time.Since(start)
-	
+
 	// Use the check's own duration if it set one and is greater, otherwise use our calculated duration
 	// Ensure there's always at least some measurable duration to avoid timer precision issues
 	if result.Duration == 0 || duration > result.Duration {
 		result.Duration = duration
 	}
-	
+
 	// Ensure minimum duration to avoid Windows timer precision issues in tests
 	if result.Duration == 0 {
 		result.Duration = 1 * time.Nanosecond
@@ -292,7 +292,7 @@ func (h *HealthChecker) GetComponentStatus(ctx context.Context, component string
 	defer h.mu.RUnlock()
 
 	results := make(map[CheckType]CheckResult)
-	
+
 	if checksByType, exists := h.checks[component]; exists {
 		for checkType, checks := range checksByType {
 			if len(checks) > 0 {
@@ -316,6 +316,6 @@ func (h *HealthChecker) ListComponents() []string {
 	for component := range h.checks {
 		components = append(components, component)
 	}
-	
+
 	return components
 }

--- a/observability/health/checker_test.go
+++ b/observability/health/checker_test.go
@@ -29,7 +29,7 @@ func (m *mockHealthCheck) Check(ctx context.Context) CheckResult {
 		// Respect context cancellation by using a timer instead of just sleeping
 		timer := time.NewTimer(m.duration)
 		defer timer.Stop()
-		
+
 		select {
 		case <-timer.C:
 			// Duration completed normally

--- a/observability/health/checks.go
+++ b/observability/health/checks.go
@@ -59,7 +59,7 @@ func WithConnectionPoolCheck() DatabaseCheckOption {
 	}
 }
 
-func (d *DatabaseCheck) Name() string     { return d.name }
+func (d *DatabaseCheck) Name() string      { return d.name }
 func (d *DatabaseCheck) Component() string { return "database" }
 
 func (d *DatabaseCheck) Check(ctx context.Context) CheckResult {
@@ -180,7 +180,7 @@ func WithHTTPClient(client *http.Client) HTTPCheckOption {
 	}
 }
 
-func (h *HTTPCheck) Name() string     { return h.name }
+func (h *HTTPCheck) Name() string      { return h.name }
 func (h *HTTPCheck) Component() string { return "http" }
 
 func (h *HTTPCheck) Check(ctx context.Context) CheckResult {
@@ -228,10 +228,10 @@ func (h *HTTPCheck) Check(ctx context.Context) CheckResult {
 
 // TCPCheck performs a TCP connectivity check.
 type TCPCheck struct {
-	name     string
-	address  string
-	timeout  time.Duration
-	dialer   *net.Dialer
+	name    string
+	address string
+	timeout time.Duration
+	dialer  *net.Dialer
 }
 
 // NewTCPCheck creates a new TCP connectivity check.
@@ -262,7 +262,7 @@ func WithTCPTimeout(timeout time.Duration) TCPCheckOption {
 	}
 }
 
-func (t *TCPCheck) Name() string     { return t.name }
+func (t *TCPCheck) Name() string      { return t.name }
 func (t *TCPCheck) Component() string { return "tcp" }
 
 func (t *TCPCheck) Check(ctx context.Context) CheckResult {
@@ -306,7 +306,7 @@ func NewMemoryCheck(name string, thresholdMB uint64) *MemoryCheck {
 	}
 }
 
-func (m *MemoryCheck) Name() string     { return m.name }
+func (m *MemoryCheck) Name() string      { return m.name }
 func (m *MemoryCheck) Component() string { return "system" }
 
 func (m *MemoryCheck) Check(ctx context.Context) CheckResult {
@@ -371,7 +371,7 @@ func (c *CompositeCheck) AddCheck(check HealthCheck) {
 	c.checks = append(c.checks, check)
 }
 
-func (c *CompositeCheck) Name() string     { return c.name }
+func (c *CompositeCheck) Name() string      { return c.name }
 func (c *CompositeCheck) Component() string { return c.comp }
 
 func (c *CompositeCheck) Check(ctx context.Context) CheckResult {
@@ -423,7 +423,7 @@ func (c *CompositeCheck) Check(ctx context.Context) CheckResult {
 
 	result.Status = overallStatus
 	result.Details["sub_checks"] = checkResults
-	
+
 	if len(messages) > 0 {
 		result.Message = fmt.Sprintf("Composite check: %v", messages)
 	} else {

--- a/observability/integration_test.go
+++ b/observability/integration_test.go
@@ -344,7 +344,7 @@ func BenchmarkObservabilityIntegration(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			// Record metrics
-			metricsAdapter.RecordSyncDuration("sync", 100 * time.Millisecond)
+			metricsAdapter.RecordSyncDuration("sync", 100*time.Millisecond)
 
 			// Check health
 			result := healthChecker.CheckLiveness(ctx)

--- a/observability/metrics/collector.go
+++ b/observability/metrics/collector.go
@@ -15,12 +15,12 @@ import (
 // Prometheus-compatible metrics for monitoring and alerting.
 type SyncKitMetrics struct {
 	// Sync operation metrics
-	syncOpsTotal         *prometheus.CounterVec
-	syncOpsDuration      *prometheus.HistogramVec
-	syncEventsProcessed  *prometheus.CounterVec
-	syncConflictsTotal   *prometheus.CounterVec
-	syncErrorsTotal      *prometheus.CounterVec
-	syncLastSuccess      *prometheus.GaugeVec
+	syncOpsTotal        *prometheus.CounterVec
+	syncOpsDuration     *prometheus.HistogramVec
+	syncEventsProcessed *prometheus.CounterVec
+	syncConflictsTotal  *prometheus.CounterVec
+	syncErrorsTotal     *prometheus.CounterVec
+	syncLastSuccess     *prometheus.GaugeVec
 
 	// Transport metrics
 	transportOpsTotal    *prometheus.CounterVec
@@ -29,28 +29,28 @@ type SyncKitMetrics struct {
 	transportErrorsTotal *prometheus.CounterVec
 
 	// Storage metrics
-	storageOpsTotal      *prometheus.CounterVec
-	storageDuration      *prometheus.HistogramVec
-	storageErrorsTotal   *prometheus.CounterVec
+	storageOpsTotal    *prometheus.CounterVec
+	storageDuration    *prometheus.HistogramVec
+	storageErrorsTotal *prometheus.CounterVec
 
 	// Conflict resolution metrics
-	conflictOpsTotal     *prometheus.CounterVec
-	conflictDuration     *prometheus.HistogramVec
+	conflictOpsTotal *prometheus.CounterVec
+	conflictDuration *prometheus.HistogramVec
 
 	// Projection metrics
-	projectionOpsTotal         *prometheus.CounterVec
-	projectionOpsDuration      *prometheus.HistogramVec
-	projectionEventsProcessed  *prometheus.CounterVec
-	projectionBatchSize        *prometheus.HistogramVec
-	projectionErrorsTotal      *prometheus.CounterVec
-	projectionLastSuccess      *prometheus.GaugeVec
-	projectionLag              *prometheus.GaugeVec
-	projectionHealth           *prometheus.GaugeVec
+	projectionOpsTotal        *prometheus.CounterVec
+	projectionOpsDuration     *prometheus.HistogramVec
+	projectionEventsProcessed *prometheus.CounterVec
+	projectionBatchSize       *prometheus.HistogramVec
+	projectionErrorsTotal     *prometheus.CounterVec
+	projectionLastSuccess     *prometheus.GaugeVec
+	projectionLag             *prometheus.GaugeVec
+	projectionHealth          *prometheus.GaugeVec
 
 	// System metrics
-	activeConnections    prometheus.Gauge
-	memoryUsage         prometheus.Gauge
-	goroutines          prometheus.Gauge
+	activeConnections prometheus.Gauge
+	memoryUsage       prometheus.Gauge
+	goroutines        prometheus.Gauge
 
 	registry *prometheus.Registry
 	labels   prometheus.Labels

--- a/observability/metrics/collector_test.go
+++ b/observability/metrics/collector_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestNewSyncKitMetrics(t *testing.T) {
 	tests := []struct {
-		name    string
+		name     string
 		registry *prometheus.Registry
-		wantErr bool
+		wantErr  bool
 	}{
 		{
 			name:     "with custom registry",
@@ -150,10 +150,10 @@ func TestSyncKitMetrics_ConcurrentAccess(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func(id int) {
 			defer func() { done <- true }()
-			
+
 			for j := 0; j < numOperations; j++ {
 				duration := time.Duration(j+1) * time.Millisecond
-				
+
 				// Record various metrics concurrently
 				metrics.RecordSyncOperation("push", duration, true, 1, 0, 0)
 				metrics.RecordTransportOperation("http", "push", duration, true, 50)

--- a/observability/tracing/attributes.go
+++ b/observability/tracing/attributes.go
@@ -12,113 +12,113 @@ var (
 	// General component and operation attributes
 	ComponentKey = attribute.Key("synckit.component")
 	OperationKey = attribute.Key("synckit.operation")
-	
-	// Sync operation attributes  
-	SyncOperationKey     = attribute.Key("synckit.sync.operation")      // "full", "push", "pull"
-	SyncPhaseKey         = attribute.Key("synckit.sync.phase")          // "start", "pull", "push", "complete"
-	SyncStrategyKey      = attribute.Key("synckit.sync.strategy")       // "bidirectional", "push_only", "pull_only"
-	
+
+	// Sync operation attributes
+	SyncOperationKey = attribute.Key("synckit.sync.operation") // "full", "push", "pull"
+	SyncPhaseKey     = attribute.Key("synckit.sync.phase")     // "start", "pull", "push", "complete"
+	SyncStrategyKey  = attribute.Key("synckit.sync.strategy")  // "bidirectional", "push_only", "pull_only"
+
 	// Event attributes
-	EventCountKey        = attribute.Key("synckit.events.count")        // Number of events processed
-	EventsPushedKey      = attribute.Key("synckit.events.pushed")       // Events sent to remote
-	EventsPulledKey      = attribute.Key("synckit.events.pulled")       // Events received from remote
-	EventTypeKey         = attribute.Key("synckit.event.type")          // Type of event
-	AggregateIDsKey      = attribute.Key("synckit.aggregates.ids")      // List of aggregate IDs
-	AggregateTypeKey     = attribute.Key("synckit.aggregate.type")      // Type of aggregate
-	
+	EventCountKey    = attribute.Key("synckit.events.count")   // Number of events processed
+	EventsPushedKey  = attribute.Key("synckit.events.pushed")  // Events sent to remote
+	EventsPulledKey  = attribute.Key("synckit.events.pulled")  // Events received from remote
+	EventTypeKey     = attribute.Key("synckit.event.type")     // Type of event
+	AggregateIDsKey  = attribute.Key("synckit.aggregates.ids") // List of aggregate IDs
+	AggregateTypeKey = attribute.Key("synckit.aggregate.type") // Type of aggregate
+
 	// Conflict resolution attributes
-	ConflictsResolvedKey = attribute.Key("synckit.conflicts.resolved")  // Number of conflicts resolved
-	ConflictStrategyKey  = attribute.Key("synckit.conflict.strategy")   // "lww", "fww", "additive", "manual"
-	ConflictDecisionKey  = attribute.Key("synckit.conflict.decision")   // Resolution decision made
-	ConflictReasonKey    = attribute.Key("synckit.conflict.reason")     // Reason for conflict resolution
-	
+	ConflictsResolvedKey = attribute.Key("synckit.conflicts.resolved") // Number of conflicts resolved
+	ConflictStrategyKey  = attribute.Key("synckit.conflict.strategy")  // "lww", "fww", "additive", "manual"
+	ConflictDecisionKey  = attribute.Key("synckit.conflict.decision")  // Resolution decision made
+	ConflictReasonKey    = attribute.Key("synckit.conflict.reason")    // Reason for conflict resolution
+
 	// Transport attributes
 	TransportOperationKey = attribute.Key("synckit.transport.operation") // "push", "pull", "get_version"
 	TransportTypeKey      = attribute.Key("synckit.transport.type")      // "http", "grpc", "nats", "null"
 	TransportEndpointKey  = attribute.Key("synckit.transport.endpoint")  // Remote endpoint URL
 	TransportMethodKey    = attribute.Key("synckit.transport.method")    // HTTP method, gRPC method, etc.
-	
-	// Storage attributes  
-	StorageOperationKey = attribute.Key("synckit.storage.operation")   // "store", "load", "latest_version"
-	StorageTypeKey      = attribute.Key("synckit.storage.type")        // "sqlite", "postgresql", "memory"
-	StorageTableKey     = attribute.Key("synckit.storage.table")       // Database table name
-	StorageQueryKey     = attribute.Key("synckit.storage.query")       // SQL query or operation
-	
+
+	// Storage attributes
+	StorageOperationKey = attribute.Key("synckit.storage.operation") // "store", "load", "latest_version"
+	StorageTypeKey      = attribute.Key("synckit.storage.type")      // "sqlite", "postgresql", "memory"
+	StorageTableKey     = attribute.Key("synckit.storage.table")     // Database table name
+	StorageQueryKey     = attribute.Key("synckit.storage.query")     // SQL query or operation
+
 	// Performance attributes
-	BatchSizeKey        = attribute.Key("synckit.batch.size")          // Batch size for operations
-	RetryCountKey       = attribute.Key("synckit.retry.count")         // Number of retry attempts
-	TimeoutKey          = attribute.Key("synckit.timeout")             // Operation timeout
-	
+	BatchSizeKey  = attribute.Key("synckit.batch.size")  // Batch size for operations
+	RetryCountKey = attribute.Key("synckit.retry.count") // Number of retry attempts
+	TimeoutKey    = attribute.Key("synckit.timeout")     // Operation timeout
+
 	// Version attributes
-	LocalVersionKey     = attribute.Key("synckit.version.local")       // Local version
-	RemoteVersionKey    = attribute.Key("synckit.version.remote")      // Remote version
-	VersionTypeKey      = attribute.Key("synckit.version.type")        // "integer", "vector_clock", "timestamp"
-	
+	LocalVersionKey  = attribute.Key("synckit.version.local")  // Local version
+	RemoteVersionKey = attribute.Key("synckit.version.remote") // Remote version
+	VersionTypeKey   = attribute.Key("synckit.version.type")   // "integer", "vector_clock", "timestamp"
+
 	// Filter attributes
-	FilterAppliedKey    = attribute.Key("synckit.filter.applied")      // Whether filtering was applied
-	FilterMatchedKey    = attribute.Key("synckit.filter.matched")      // Number of events that matched filter
-	FilterTotalKey      = attribute.Key("synckit.filter.total")        // Total events before filtering
-	
+	FilterAppliedKey = attribute.Key("synckit.filter.applied") // Whether filtering was applied
+	FilterMatchedKey = attribute.Key("synckit.filter.matched") // Number of events that matched filter
+	FilterTotalKey   = attribute.Key("synckit.filter.total")   // Total events before filtering
+
 	// Error attributes (extending standard OpenTelemetry error attributes)
-	ErrorCodeKey        = attribute.Key("synckit.error.code")          // Sync-kit specific error code
-	ErrorComponentKey   = attribute.Key("synckit.error.component")     // Component where error occurred
-	ErrorRetryableKey   = attribute.Key("synckit.error.retryable")     // Whether error is retryable
-	
+	ErrorCodeKey      = attribute.Key("synckit.error.code")      // Sync-kit specific error code
+	ErrorComponentKey = attribute.Key("synckit.error.component") // Component where error occurred
+	ErrorRetryableKey = attribute.Key("synckit.error.retryable") // Whether error is retryable
+
 	// Health check attributes
-	HealthCheckTypeKey  = attribute.Key("synckit.health.check_type")   // "liveness", "readiness", "startup"
-	HealthStatusKey     = attribute.Key("synckit.health.status")       // "up", "down", "degraded"
-	HealthComponentKey  = attribute.Key("synckit.health.component")    // Component being checked
-	
+	HealthCheckTypeKey = attribute.Key("synckit.health.check_type") // "liveness", "readiness", "startup"
+	HealthStatusKey    = attribute.Key("synckit.health.status")     // "up", "down", "degraded"
+	HealthComponentKey = attribute.Key("synckit.health.component")  // Component being checked
+
 	// Real-time sync attributes
-	RealtimeEnabledKey     = attribute.Key("synckit.realtime.enabled")     // Whether real-time sync is enabled
+	RealtimeEnabledKey      = attribute.Key("synckit.realtime.enabled")      // Whether real-time sync is enabled
 	RealtimeNotificationKey = attribute.Key("synckit.realtime.notification") // Type of real-time notification
-	RealtimeConnectionKey   = attribute.Key("synckit.realtime.connection")  // Connection status
+	RealtimeConnectionKey   = attribute.Key("synckit.realtime.connection")   // Connection status
 )
 
 // Standard attribute values for consistent reporting
 const (
 	// Sync operation values
 	SyncOperationFull = "full"
-	SyncOperationPush = "push" 
+	SyncOperationPush = "push"
 	SyncOperationPull = "pull"
-	
+
 	// Sync phase values
 	SyncPhaseStart    = "start"
 	SyncPhasePull     = "pull"
-	SyncPhasePush     = "push" 
+	SyncPhasePush     = "push"
 	SyncPhaseComplete = "complete"
-	
+
 	// Conflict strategy values
-	ConflictStrategyLWW       = "last_write_wins"
-	ConflictStrategyFWW       = "first_write_wins"
-	ConflictStrategyAdditive  = "additive_merge"
-	ConflictStrategyManual    = "manual"
-	ConflictStrategyCustom    = "custom"
-	
+	ConflictStrategyLWW      = "last_write_wins"
+	ConflictStrategyFWW      = "first_write_wins"
+	ConflictStrategyAdditive = "additive_merge"
+	ConflictStrategyManual   = "manual"
+	ConflictStrategyCustom   = "custom"
+
 	// Transport type values
 	TransportTypeHTTP = "http"
 	TransportTypeGRPC = "grpc"
 	TransportTypeNATS = "nats"
 	TransportTypeNull = "null"
-	
-	// Storage type values  
+
+	// Storage type values
 	StorageTypeSQLite     = "sqlite"
 	StorageTypePostgreSQL = "postgresql"
 	StorageTypeMemory     = "memory"
-	
+
 	// Component values
-	ComponentSyncKit         = "synckit"
-	ComponentTransport       = "transport"
-	ComponentStorage         = "storage"
+	ComponentSyncKit          = "synckit"
+	ComponentTransport        = "transport"
+	ComponentStorage          = "storage"
 	ComponentConflictResolver = "conflict-resolver"
-	ComponentHealthCheck     = "health-check"
-	
+	ComponentHealthCheck      = "health-check"
+
 	// Health status values
 	HealthStatusUp       = "up"
-	HealthStatusDown     = "down" 
+	HealthStatusDown     = "down"
 	HealthStatusDegraded = "degraded"
 	HealthStatusUnknown  = "unknown"
-	
+
 	// Health check type values
 	HealthCheckTypeLiveness  = "liveness"
 	HealthCheckTypeReadiness = "readiness"
@@ -176,7 +176,7 @@ func SanitizeStringAttribute(value string, maxLength int) string {
 	return value[:maxLength-3] + "..."
 }
 
-// SanitizeSliceAttribute ensures slice attributes don't exceed reasonable limits  
+// SanitizeSliceAttribute ensures slice attributes don't exceed reasonable limits
 func SanitizeSliceAttribute(values []string, maxItems int) []string {
 	if len(values) <= maxItems {
 		return values

--- a/observability/tracing/attributes_test.go
+++ b/observability/tracing/attributes_test.go
@@ -12,7 +12,7 @@ func TestSyncKitAttributes(t *testing.T) {
 	// Test that core attribute keys are defined
 	expectedKeys := []string{
 		"synckit.component",
-		"synckit.operation", 
+		"synckit.operation",
 		"synckit.sync.operation",
 		"synckit.sync.phase",
 		"synckit.events.count",
@@ -30,21 +30,21 @@ func TestSyncKitAttributes(t *testing.T) {
 
 	// Create map of actual keys
 	actualKeys := map[string]bool{
-		string(ComponentKey):         true,
-		string(OperationKey):         true,
-		string(SyncOperationKey):     true,
-		string(SyncPhaseKey):         true,
-		string(EventCountKey):        true,
-		string(EventsPushedKey):      true,
-		string(EventsPulledKey):      true,
-		string(AggregateIDsKey):      true,
-		string(ConflictsResolvedKey): true,
-		string(ConflictStrategyKey):  true,
+		string(ComponentKey):          true,
+		string(OperationKey):          true,
+		string(SyncOperationKey):      true,
+		string(SyncPhaseKey):          true,
+		string(EventCountKey):         true,
+		string(EventsPushedKey):       true,
+		string(EventsPulledKey):       true,
+		string(AggregateIDsKey):       true,
+		string(ConflictsResolvedKey):  true,
+		string(ConflictStrategyKey):   true,
 		string(TransportOperationKey): true,
-		string(TransportTypeKey):     true,
-		string(StorageOperationKey):  true,
-		string(StorageTypeKey):       true,
-		string(HealthStatusKey):      true,
+		string(TransportTypeKey):      true,
+		string(StorageOperationKey):   true,
+		string(StorageTypeKey):        true,
+		string(HealthStatusKey):       true,
 	}
 
 	// Check all expected keys exist

--- a/observability/tracing/middleware.go
+++ b/observability/tracing/middleware.go
@@ -16,8 +16,8 @@ import (
 // It automatically creates spans for incoming HTTP requests with proper
 // context propagation and standard HTTP semantic conventions.
 type HTTPMiddleware struct {
-	tracer     trace.Tracer
-	propagator propagation.TextMapPropagator
+	tracer      trace.Tracer
+	propagator  propagation.TextMapPropagator
 	serviceName string
 }
 
@@ -37,13 +37,13 @@ func (m *HTTPMiddleware) Handler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Extract trace context from incoming request headers
 		ctx := m.propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
-		
+
 		// Create span name based on HTTP method and route
 		spanName := r.Method + " " + r.URL.Path
 		if spanName == "" {
 			spanName = "HTTP " + r.Method
 		}
-		
+
 		// Start new span with extracted context
 		ctx, span := m.tracer.Start(ctx, spanName,
 			trace.WithAttributes(
@@ -55,7 +55,7 @@ func (m *HTTPMiddleware) Handler(handler http.Handler) http.Handler {
 				attribute.String("http.target", r.URL.Path),
 				attribute.String("http.user_agent", r.UserAgent()),
 				attribute.String("http.route", r.URL.Path),
-				
+
 				// Sync-kit specific attributes
 				attribute.String("service.name", m.serviceName),
 				ComponentKey.String(ComponentTransport),
@@ -63,19 +63,19 @@ func (m *HTTPMiddleware) Handler(handler http.Handler) http.Handler {
 			trace.WithSpanKind(trace.SpanKindServer),
 		)
 		defer span.End()
-		
+
 		// Wrap response writer to capture status code and response size
 		ww := &wrappedResponseWriter{
 			ResponseWriter: w,
 			statusCode:     200, // Default to 200 if WriteHeader is not called
 		}
-		
+
 		// Record request start time
 		start := time.Now()
-		
+
 		// Execute the handler with the traced context
 		handler.ServeHTTP(ww, r.WithContext(ctx))
-		
+
 		// Record final span attributes after request completion
 		duration := time.Since(start)
 		span.SetAttributes(
@@ -83,7 +83,7 @@ func (m *HTTPMiddleware) Handler(handler http.Handler) http.Handler {
 			attribute.Int64("http.response_size", ww.bytesWritten),
 			attribute.Float64("http.duration_ms", float64(duration.Nanoseconds())/1e6),
 		)
-		
+
 		// Set span status based on HTTP status code
 		if ww.statusCode >= 400 {
 			span.SetStatus(codes.Error, http.StatusText(ww.statusCode))
@@ -91,7 +91,7 @@ func (m *HTTPMiddleware) Handler(handler http.Handler) http.Handler {
 		} else {
 			span.SetStatus(codes.Ok, "Request completed successfully")
 		}
-		
+
 		// Add events for significant status codes
 		if ww.statusCode >= 500 {
 			span.AddEvent("server_error", trace.WithAttributes(
@@ -113,9 +113,9 @@ func (m *HTTPMiddleware) HandlerFunc(handler http.HandlerFunc) http.HandlerFunc 
 // wrappedResponseWriter captures response data for tracing
 type wrappedResponseWriter struct {
 	http.ResponseWriter
-	statusCode     int
-	bytesWritten   int64
-	headerWritten  bool
+	statusCode    int
+	bytesWritten  int64
+	headerWritten bool
 }
 
 func (w *wrappedResponseWriter) WriteHeader(statusCode int) {
@@ -147,7 +147,7 @@ func NewClientTransport(base http.RoundTripper) *ClientTransport {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	
+
 	return &ClientTransport{
 		base:       base,
 		tracer:     otel.Tracer("github.com/c0deZ3R0/go-sync-kit/http-client"),
@@ -159,7 +159,7 @@ func NewClientTransport(base http.RoundTripper) *ClientTransport {
 func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create span name based on HTTP method and host
 	spanName := req.Method + " " + req.URL.Host
-	
+
 	// Start new span for outgoing request
 	ctx, span := t.tracer.Start(req.Context(), spanName,
 		trace.WithAttributes(
@@ -169,7 +169,7 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			attribute.String("http.scheme", req.URL.Scheme),
 			attribute.String("http.host", req.URL.Host),
 			attribute.String("http.target", req.URL.Path),
-			
+
 			// Sync-kit specific attributes
 			ComponentKey.String(ComponentTransport),
 			TransportTypeKey.String(TransportTypeHTTP),
@@ -177,15 +177,15 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		trace.WithSpanKind(trace.SpanKindClient),
 	)
 	defer span.End()
-	
+
 	// Inject trace context into request headers
 	t.propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
-	
+
 	// Execute the request
 	start := time.Now()
 	resp, err := t.base.RoundTrip(req.WithContext(ctx))
 	duration := time.Since(start)
-	
+
 	// Record response attributes
 	if err != nil {
 		span.SetStatus(codes.Error, "Request failed")
@@ -198,7 +198,7 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			attribute.Int("http.status_code", resp.StatusCode),
 			attribute.Float64("http.duration_ms", float64(duration.Nanoseconds())/1e6),
 		)
-		
+
 		// Set status based on response code
 		if resp.StatusCode >= 400 {
 			span.SetStatus(codes.Error, http.StatusText(resp.StatusCode))
@@ -206,13 +206,13 @@ func (t *ClientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		} else {
 			span.SetStatus(codes.Ok, "Request completed successfully")
 		}
-		
+
 		// Add response size if available
 		if resp.ContentLength > 0 {
 			span.SetAttributes(attribute.Int64("http.response_size", resp.ContentLength))
 		}
 	}
-	
+
 	return resp, err
 }
 
@@ -229,7 +229,7 @@ func NewHTTPMiddlewareWithConfig(config TraceConfig) *HTTPMiddleware {
 	if config.ServiceName == "" {
 		config.ServiceName = "sync-kit-service"
 	}
-	
+
 	return &HTTPMiddleware{
 		tracer:      otel.Tracer("github.com/c0deZ3R0/go-sync-kit/http"),
 		propagator:  otel.GetTextMapPropagator(),
@@ -243,7 +243,7 @@ func (m *HTTPMiddleware) shouldSkipTracing(r *http.Request, config TraceConfig) 
 	if config.SkipHealthCheck && (r.URL.Path == "/health" || r.URL.Path == "/healthz") {
 		return true
 	}
-	
+
 	// Skip specific user agents if configured
 	userAgent := r.UserAgent()
 	for _, skipUA := range config.SkipUserAgent {
@@ -251,32 +251,32 @@ func (m *HTTPMiddleware) shouldSkipTracing(r *http.Request, config TraceConfig) 
 			return true
 		}
 	}
-	
+
 	return false
 }
 
 // extractSyncKitHeaders extracts sync-kit specific headers for tracing
 func extractSyncKitHeaders(r *http.Request) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
-	
+
 	// Extract sync-kit specific headers
 	if syncID := r.Header.Get("X-Sync-ID"); syncID != "" {
 		attrs = append(attrs, attribute.String("synckit.sync_id", syncID))
 	}
-	
+
 	if clientID := r.Header.Get("X-Client-ID"); clientID != "" {
 		attrs = append(attrs, attribute.String("synckit.client_id", clientID))
 	}
-	
+
 	if version := r.Header.Get("X-Sync-Version"); version != "" {
 		attrs = append(attrs, attribute.String("synckit.sync_version", version))
 	}
-	
+
 	if batchSize := r.Header.Get("X-Batch-Size"); batchSize != "" {
 		if size, err := strconv.Atoi(batchSize); err == nil {
 			attrs = append(attrs, BatchSizeKey.Int(size))
 		}
 	}
-	
+
 	return attrs
 }

--- a/observability/tracing/middleware_test.go
+++ b/observability/tracing/middleware_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestHTTPMiddleware(t *testing.T) {

--- a/observability/tracing/tracer.go
+++ b/observability/tracing/tracer.go
@@ -53,7 +53,7 @@ func WithAttributes(attrs ...attribute.KeyValue) TracerOption {
 // It uses the global OpenTelemetry tracer provider to create the underlying tracer.
 func NewTracer(serviceName string, opts ...TracerOption) *SyncKitTracer {
 	tracer := otel.Tracer("github.com/c0deZ3R0/go-sync-kit")
-	
+
 	t := &SyncKitTracer{
 		tracer:      tracer,
 		serviceName: serviceName,
@@ -62,11 +62,11 @@ func NewTracer(serviceName string, opts ...TracerOption) *SyncKitTracer {
 			attribute.String("library.name", "go-sync-kit"),
 		},
 	}
-	
+
 	for _, opt := range opts {
 		opt(t)
 	}
-	
+
 	return t
 }
 
@@ -74,13 +74,13 @@ func NewTracer(serviceName string, opts ...TracerOption) *SyncKitTracer {
 // It automatically sets standard attributes and naming conventions.
 func (t *SyncKitTracer) StartSyncOperation(ctx context.Context, operation string) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("synckit.sync.%s", operation)
-	
+
 	attrs := append([]attribute.KeyValue{
 		SyncOperationKey.String(operation),
 		SyncPhaseKey.String("start"),
 		ComponentKey.String("synckit"),
 	}, t.attributes...)
-	
+
 	return t.tracer.Start(ctx, spanName,
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -90,13 +90,13 @@ func (t *SyncKitTracer) StartSyncOperation(ctx context.Context, operation string
 // StartTransportOperation starts a new span for a transport operation.
 func (t *SyncKitTracer) StartTransportOperation(ctx context.Context, operation, transport string) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("synckit.transport.%s", operation)
-	
+
 	attrs := append([]attribute.KeyValue{
 		TransportOperationKey.String(operation),
 		TransportTypeKey.String(transport),
 		ComponentKey.String("transport"),
 	}, t.attributes...)
-	
+
 	return t.tracer.Start(ctx, spanName,
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -106,13 +106,13 @@ func (t *SyncKitTracer) StartTransportOperation(ctx context.Context, operation, 
 // StartStorageOperation starts a new span for a storage operation.
 func (t *SyncKitTracer) StartStorageOperation(ctx context.Context, operation, storageType string) (context.Context, trace.Span) {
 	spanName := fmt.Sprintf("synckit.storage.%s", operation)
-	
+
 	attrs := append([]attribute.KeyValue{
 		StorageOperationKey.String(operation),
 		StorageTypeKey.String(storageType),
 		ComponentKey.String("storage"),
 	}, t.attributes...)
-	
+
 	return t.tracer.Start(ctx, spanName,
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -122,12 +122,12 @@ func (t *SyncKitTracer) StartStorageOperation(ctx context.Context, operation, st
 // StartConflictResolution starts a new span for conflict resolution.
 func (t *SyncKitTracer) StartConflictResolution(ctx context.Context, strategy string) (context.Context, trace.Span) {
 	spanName := "synckit.conflict.resolve"
-	
+
 	attrs := append([]attribute.KeyValue{
 		ConflictStrategyKey.String(strategy),
 		ComponentKey.String("conflict-resolver"),
 	}, t.attributes...)
-	
+
 	return t.tracer.Start(ctx, spanName,
 		trace.WithAttributes(attrs...),
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -139,7 +139,7 @@ func (t *SyncKitTracer) AddEventAttributes(span trace.Span, eventCount int, aggr
 	attrs := []attribute.KeyValue{
 		EventCountKey.Int(eventCount),
 	}
-	
+
 	if len(aggregateIDs) > 0 {
 		// Limit the number of aggregate IDs to prevent span size issues
 		maxAggregateIDs := 10
@@ -150,7 +150,7 @@ func (t *SyncKitTracer) AddEventAttributes(span trace.Span, eventCount int, aggr
 			attrs = append(attrs, AggregateIDsKey.StringSlice(aggregateIDs))
 		}
 	}
-	
+
 	span.SetAttributes(attrs...)
 }
 
@@ -159,7 +159,7 @@ func (t *SyncKitTracer) RecordError(span trace.Span, err error, description stri
 	if err == nil {
 		return
 	}
-	
+
 	span.SetStatus(codes.Error, description)
 	span.RecordError(err, trace.WithAttributes(
 		attribute.String("error.type", fmt.Sprintf("%T", err)),
@@ -175,7 +175,7 @@ func (t *SyncKitTracer) SetSyncResult(span trace.Span, eventsPushed, eventsPulle
 		ConflictsResolvedKey.Int(conflictsResolved),
 		attribute.Bool("success", true),
 	)
-	
+
 	span.SetStatus(codes.Ok, "Sync operation completed successfully")
 }
 

--- a/observability/tracing/tracer_test.go
+++ b/observability/tracing/tracer_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestNewTracer(t *testing.T) {
 	serviceName := "test-service"
-	
+
 	tracer := NewTracer(serviceName)
-	
+
 	if tracer == nil {
 		t.Fatal("Expected tracer to be created, got nil")
 	}
-	
+
 	if tracer.serviceName != serviceName {
 		t.Errorf("Expected service name %s, got %s", serviceName, tracer.serviceName)
 	}
@@ -26,20 +26,20 @@ func TestNewTracer(t *testing.T) {
 func TestTracerWithOptions(t *testing.T) {
 	serviceName := "test-service"
 	version := "v1.0.0"
-	
+
 	tracer := NewTracer(serviceName,
 		WithVersion(version),
 		WithAttributes(attribute.String("custom", "value")),
 	)
-	
+
 	if tracer.serviceName != serviceName {
 		t.Errorf("Expected service name %s, got %s", serviceName, tracer.serviceName)
 	}
-	
+
 	if tracer.version != version {
 		t.Errorf("Expected version %s, got %s", version, tracer.version)
 	}
-	
+
 	// Check that custom attributes were added
 	found := false
 	for _, attr := range tracer.attributes {
@@ -48,7 +48,7 @@ func TestTracerWithOptions(t *testing.T) {
 			break
 		}
 	}
-	
+
 	if !found {
 		t.Error("Expected custom attribute to be added")
 	}
@@ -58,17 +58,17 @@ func TestStartSyncOperation(t *testing.T) {
 	// Set up a test tracer provider
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
 	operation := "full_sync"
-	
+
 	ctx, span := tracer.StartSyncOperation(ctx, operation)
-	
+
 	if span == nil {
 		t.Fatal("Expected span to be created, got nil")
 	}
-	
+
 	// Clean up
 	span.End()
 }
@@ -76,16 +76,16 @@ func TestStartSyncOperation(t *testing.T) {
 func TestRecordError(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartSyncOperation(ctx, "test")
 	defer span.End()
-	
+
 	testError := &testError{"test error"}
 	description := "Test error occurred"
-	
+
 	// This should not panic
 	tracer.RecordError(span, testError, description)
 }
@@ -93,13 +93,13 @@ func TestRecordError(t *testing.T) {
 func TestSetSyncResult(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartSyncOperation(ctx, "test")
 	defer span.End()
-	
+
 	// This should not panic
 	tracer.SetSyncResult(span, 10, 5, 2)
 }
@@ -107,16 +107,16 @@ func TestSetSyncResult(t *testing.T) {
 func TestAddEventAttributes(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartSyncOperation(ctx, "test")
 	defer span.End()
-	
+
 	eventCount := 15
 	aggregateIDs := []string{"agg1", "agg2", "agg3"}
-	
+
 	// This should not panic
 	tracer.AddEventAttributes(span, eventCount, aggregateIDs)
 }
@@ -124,20 +124,20 @@ func TestAddEventAttributes(t *testing.T) {
 func TestAddEventAttributesTooManyAggregates(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartSyncOperation(ctx, "test")
 	defer span.End()
-	
+
 	eventCount := 15
 	// Create more than maxAggregateIDs (10)
 	aggregateIDs := make([]string, 15)
 	for i := 0; i < 15; i++ {
 		aggregateIDs[i] = "agg" + string(rune('0'+i))
 	}
-	
+
 	// This should not panic and should truncate the list
 	tracer.AddEventAttributes(span, eventCount, aggregateIDs)
 }
@@ -145,63 +145,63 @@ func TestAddEventAttributesTooManyAggregates(t *testing.T) {
 func TestStartTransportOperation(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartTransportOperation(ctx, "push", "http")
-	
+
 	if span == nil {
 		t.Fatal("Expected span to be created, got nil")
 	}
-	
+
 	span.End()
 }
 
 func TestStartStorageOperation(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartStorageOperation(ctx, "store", "sqlite")
-	
+
 	if span == nil {
 		t.Fatal("Expected span to be created, got nil")
 	}
-	
+
 	span.End()
 }
 
 func TestStartConflictResolution(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartConflictResolution(ctx, "last_write_wins")
-	
+
 	if span == nil {
 		t.Fatal("Expected span to be created, got nil")
 	}
-	
+
 	span.End()
 }
 
 func TestAddSpanEvent(t *testing.T) {
 	tp := tracesdk.NewTracerProvider()
 	otel.SetTracerProvider(tp)
-	
+
 	tracer := NewTracer("test-service")
 	ctx := context.Background()
-	
+
 	ctx, span := tracer.StartSyncOperation(ctx, "test")
 	defer span.End()
-	
+
 	// This should not panic
-	tracer.AddSpanEvent(span, "test.event", 
+	tracer.AddSpanEvent(span, "test.event",
 		attribute.String("test", "value"),
 		attribute.Int("count", 42),
 	)

--- a/projection/badger/offsets.go
+++ b/projection/badger/offsets.go
@@ -17,11 +17,11 @@ import (
 // OffsetStore implements projection.OffsetStore using BadgerDB as the backend.
 // It provides high-performance offset persistence with excellent concurrent access patterns.
 type OffsetStore struct {
-	db     *badger.DB
+	db           *badger.DB
 	parseVersion func(ctx context.Context, s string) (synckit.Version, error)
-	logger *slog.Logger
-	mu     sync.RWMutex
-	closed bool
+	logger       *slog.Logger
+	mu           sync.RWMutex
+	closed       bool
 }
 
 // OffsetStoreOption configures an OffsetStore using the functional options pattern.

--- a/projection/interfaces.go
+++ b/projection/interfaces.go
@@ -59,9 +59,9 @@ type RunnerOption func(*runner)
 // WithBatchSize sets the batch size for processing events.
 // Default is 500 events per batch.
 func WithBatchSize(n int) RunnerOption {
-	return func(r *runner) { 
+	return func(r *runner) {
 		if n > 0 {
-			r.batchSize = n 
+			r.batchSize = n
 		}
 	}
 }
@@ -69,9 +69,9 @@ func WithBatchSize(n int) RunnerOption {
 // WithLogger sets a custom structured logger for the runner.
 // If not provided, uses the default logger from the logging package.
 func WithLogger(logger *slog.Logger) RunnerOption {
-	return func(r *runner) { 
+	return func(r *runner) {
 		if logger != nil {
-			r.logger = logger 
+			r.logger = logger
 		}
 	}
 }
@@ -79,7 +79,7 @@ func WithLogger(logger *slog.Logger) RunnerOption {
 // WithMetrics enables metrics collection using the provided SyncKitMetrics instance.
 // This integrates the runner with the unified observability system.
 func WithMetrics(metricsCollector *metrics.SyncKitMetrics) RunnerOption {
-	return func(r *runner) { 
+	return func(r *runner) {
 		r.metricsEnabled = true
 		r.metrics = metricsCollector
 	}
@@ -88,7 +88,7 @@ func WithMetrics(metricsCollector *metrics.SyncKitMetrics) RunnerOption {
 // WithMetricsEnabled enables basic metrics collection using the legacy system.
 // For new code, prefer WithMetrics() with SyncKitMetrics for better integration.
 func WithMetricsEnabled(enabled bool) RunnerOption {
-	return func(r *runner) { 
+	return func(r *runner) {
 		r.metricsEnabled = enabled
 		// Try to use default projection metrics if available
 		if enabled && r.metrics == nil {
@@ -117,4 +117,3 @@ func NewRunner(store synckit.EventStore, offsets OffsetStore, proj Projector, op
 
 	return r
 }
-

--- a/projection/interfaces_test.go
+++ b/projection/interfaces_test.go
@@ -39,8 +39,8 @@ func (t *TestOffsetStore) Set(ctx context.Context, name string, v synckit.Versio
 
 // TestProjector implements a simple projector for testing
 type TestProjector struct {
-	name     string
-	applied  []synckit.EventWithVersion
+	name        string
+	applied     []synckit.EventWithVersion
 	shouldError bool
 }
 
@@ -59,7 +59,7 @@ func (p *TestProjector) Apply(ctx context.Context, batch []synckit.EventWithVers
 	if p.shouldError {
 		return &TestError{msg: "test error in Apply"}
 	}
-	
+
 	// Append events to applied slice (idempotent behavior would check for duplicates)
 	p.applied = append(p.applied, batch...)
 	return nil
@@ -113,7 +113,7 @@ func (s *TestEventStore) Store(ctx context.Context, event synckit.Event, version
 	if version == nil {
 		version = cursor.IntegerCursor{Seq: uint64(len(s.events) + 1)}
 	}
-	
+
 	s.events = append(s.events, synckit.EventWithVersion{
 		Event:   event,
 		Version: version,
@@ -125,7 +125,7 @@ func (s *TestEventStore) Load(ctx context.Context, since synckit.Version) ([]syn
 	if since == nil {
 		return s.events, nil
 	}
-	
+
 	var result []synckit.EventWithVersion
 	for _, ev := range s.events {
 		if ev.Version.Compare(since) > 0 {
@@ -140,7 +140,7 @@ func (s *TestEventStore) LoadByAggregate(ctx context.Context, aggregateID string
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var result []synckit.EventWithVersion
 	for _, ev := range events {
 		if ev.Event.AggregateID() == aggregateID {
@@ -181,10 +181,10 @@ func TestProjectionInterfaces(t *testing.T) {
 	offsetStore := NewTestOffsetStore()
 	projector := NewTestProjector("test-projector")
 	eventStore := NewTestEventStore()
-	
+
 	// Test OffsetStore interface
 	ctx := context.Background()
-	
+
 	// Test Get when no offset exists
 	offset, err := offsetStore.Get(ctx, "test-projector")
 	if err != nil {
@@ -193,14 +193,14 @@ func TestProjectionInterfaces(t *testing.T) {
 	if offset != nil {
 		t.Fatalf("Expected nil offset, got: %v", offset)
 	}
-	
+
 	// Test Set and Get
 	testVersion := cursor.IntegerCursor{Seq: 42}
 	err = offsetStore.Set(ctx, "test-projector", testVersion)
 	if err != nil {
 		t.Fatalf("Expected no error setting offset, got: %v", err)
 	}
-	
+
 	offset, err = offsetStore.Get(ctx, "test-projector")
 	if err != nil {
 		t.Fatalf("Expected no error getting offset, got: %v", err)
@@ -211,18 +211,18 @@ func TestProjectionInterfaces(t *testing.T) {
 	if offset.Compare(testVersion) != 0 {
 		t.Fatalf("Expected offset %v, got %v", testVersion, offset)
 	}
-	
+
 	// Test Projector interface
 	if projector.Name() != "test-projector" {
 		t.Fatalf("Expected name 'test-projector', got: %s", projector.Name())
 	}
-	
+
 	// Test Runner creation with various options
 	runner := NewRunner(eventStore, offsetStore, projector)
 	if runner == nil {
 		t.Fatalf("Expected runner, got nil")
 	}
-	
+
 	// Test with options
 	runnerWithOptions := NewRunner(eventStore, offsetStore, projector,
 		WithBatchSize(100),
@@ -237,20 +237,20 @@ func TestRunnerOptions(t *testing.T) {
 	offsetStore := NewTestOffsetStore()
 	projector := NewTestProjector("test-projector")
 	eventStore := NewTestEventStore()
-	
+
 	// Test invalid batch size (should be ignored)
 	runner := NewRunner(eventStore, offsetStore, projector,
-		WithBatchSize(-1), // Invalid, should be ignored
-		WithBatchSize(0),  // Invalid, should be ignored
+		WithBatchSize(-1),  // Invalid, should be ignored
+		WithBatchSize(0),   // Invalid, should be ignored
 		WithBatchSize(250), // Valid
 	)
-	
+
 	// We can't directly test the internal batchSize field, but we can verify
 	// the runner was created successfully
 	if runner == nil {
 		t.Fatalf("Expected runner, got nil")
 	}
-	
+
 	// Test nil logger (should be ignored)
 	runnerWithNilLogger := NewRunner(eventStore, offsetStore, projector,
 		WithLogger(nil), // Should be ignored

--- a/projection/metrics.go
+++ b/projection/metrics.go
@@ -12,16 +12,16 @@ import (
 // This follows the same pattern as SyncKitMetrics in observability/metrics.
 type ProjectionMetrics struct {
 	// Operations metrics
-	opsTotal         *prometheus.CounterVec
-	opsDuration      *prometheus.HistogramVec
-	eventsProcessed  *prometheus.CounterVec
-	batchSize        *prometheus.HistogramVec
-	errorsTotal      *prometheus.CounterVec
-	lastSuccess      *prometheus.GaugeVec
+	opsTotal        *prometheus.CounterVec
+	opsDuration     *prometheus.HistogramVec
+	eventsProcessed *prometheus.CounterVec
+	batchSize       *prometheus.HistogramVec
+	errorsTotal     *prometheus.CounterVec
+	lastSuccess     *prometheus.GaugeVec
 
 	// Performance metrics
-	lag              *prometheus.GaugeVec
-	health           *prometheus.GaugeVec
+	lag    *prometheus.GaugeVec
+	health *prometheus.GaugeVec
 
 	registry *prometheus.Registry
 	labels   prometheus.Labels
@@ -230,14 +230,14 @@ func (m *ProjectionMetrics) SetProjectionHealth(projection string, healthy bool)
 // In production, metrics should be accessed via the Prometheus HTTP endpoint.
 func (m *ProjectionMetrics) GetProjectionMetrics(projection string) map[string]float64 {
 	metrics := make(map[string]float64)
-	
+
 	// Note: This is a simplified implementation that returns placeholder values.
 	// For full metric access, use the Prometheus /metrics endpoint.
 	metrics["operations_total"] = 0
 	metrics["errors_total"] = 0
 	metrics["lag_seconds"] = 0
 	metrics["health"] = 1
-	
+
 	return metrics
 }
 
@@ -251,18 +251,18 @@ func (m *ProjectionMetrics) ResetProjectionMetrics(projection string) {
 	m.batchSize.DeleteLabelValues(projection)
 	m.health.DeleteLabelValues(projection)
 	m.lag.DeleteLabelValues(projection)
-	
+
 	// Delete histogram series for all operations
 	m.opsDuration.DeletePartialMatch(prometheus.Labels{"projection": projection})
 }
 
 // Error type constants for consistent error reporting
 const (
-	ErrorTypeApply     = "apply_error"
-	ErrorTypeOffset    = "offset_error"
-	ErrorTypeLoad      = "load_error"
-	ErrorTypeTimeout   = "timeout_error"
-	ErrorTypeContext   = "context_error"
+	ErrorTypeApply   = "apply_error"
+	ErrorTypeOffset  = "offset_error"
+	ErrorTypeLoad    = "load_error"
+	ErrorTypeTimeout = "timeout_error"
+	ErrorTypeContext = "context_error"
 )
 
 // Operation type constants for metrics labeling

--- a/projection/runner.go
+++ b/projection/runner.go
@@ -27,23 +27,23 @@ type runner struct {
 // the event store's zero version when no offset has been stored yet.
 func (r *runner) getStartVersion(ctx context.Context) (synckit.Version, error) {
 	projectionName := r.projector.Name()
-	
+
 	offset, err := r.offsets.Get(ctx, projectionName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get offset for projection %s: %w", projectionName, err)
 	}
-	
+
 	if offset != nil {
 		return offset, nil
 	}
-	
+
 	// No stored offset - start from beginning
 	// Use store's ParseVersion with empty string to get zero version
 	zeroVersion, err := r.store.ParseVersion(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zero version for projection start: %w", err)
 	}
-	
+
 	return zeroVersion, nil
 }
 
@@ -52,7 +52,7 @@ func (r *runner) getStartVersion(ctx context.Context) (synckit.Version, error) {
 func (r *runner) ApplySince(ctx context.Context) (applied int, last synckit.Version, err error) {
 	projectionName := r.projector.Name()
 	start := time.Now()
-	
+
 	// Record error and return early on failure
 	defer func() {
 		if err != nil && r.metricsEnabled && r.metrics != nil {
@@ -63,7 +63,7 @@ func (r *runner) ApplySince(ctx context.Context) (applied int, last synckit.Vers
 			r.metrics.RecordProjectionError(projectionName, OperationApplySince, errorType)
 		}
 	}()
-	
+
 	// Get the starting version, handling nil offset gracefully
 	startVersion, err := r.getStartVersion(ctx)
 	if err != nil {
@@ -142,7 +142,7 @@ func (r *runner) ApplySince(ctx context.Context) (applied int, last synckit.Vers
 	if r.metricsEnabled && r.metrics != nil && totalApplied > 0 {
 		duration := time.Since(start)
 		r.metrics.RecordProjectionOperation(projectionName, OperationApplySince, duration, true, totalApplied)
-		
+
 		// Calculate and record lag if we have events
 		if lastProcessed != nil {
 			// For now, we can't easily calculate lag without event timestamps
@@ -162,7 +162,7 @@ func (r *runner) ApplyBatch(ctx context.Context, batch []synckit.EventWithVersio
 
 	projectionName := r.projector.Name()
 	start := time.Now()
-	
+
 	// Apply the events to the projector
 	if err := r.projector.Apply(ctx, batch); err != nil {
 		if r.metricsEnabled && r.metrics != nil {

--- a/scripts/format.ps1
+++ b/scripts/format.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+
+Get-ChildItem -Recurse -Include *.go -File |
+  ForEach-Object {
+    & gofmt -w $_.FullName
+  }

--- a/scripts/race-no-pg.ps1
+++ b/scripts/race-no-pg.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+$pkgs = go list ./...
+$filtered = @()
+foreach ($p in $pkgs) {
+  if ($p -notmatch 'storage/postgres($|/)') { $filtered += $p }
+}
+
+if ($filtered.Length -eq 0) {
+  Write-Host 'No packages to test'
+  exit 0
+}
+
+& go test $filtered -race -count=1

--- a/scripts/test-no-pg.ps1
+++ b/scripts/test-no-pg.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+
+$pkgs = go list ./...
+$filtered = @()
+foreach ($p in $pkgs) {
+  if ($p -notmatch 'storage/postgres($|/)') { $filtered += $p }
+}
+
+if ($filtered.Length -eq 0) {
+  Write-Host 'No packages to test'
+  exit 0
+}
+
+# Invoke go test on all filtered packages
+& go test $filtered -count=1

--- a/storage/postgres/example/main.go
+++ b/storage/postgres/example/main.go
@@ -21,10 +21,10 @@ type UserEvent struct {
 	timestamp   time.Time
 }
 
-func (e *UserEvent) ID() string          { return e.id }
-func (e *UserEvent) Type() string        { return e.eventType }
-func (e *UserEvent) AggregateID() string { return e.aggregateID }
-func (e *UserEvent) Data() interface{}   { return e.data }
+func (e *UserEvent) ID() string                       { return e.id }
+func (e *UserEvent) Type() string                     { return e.eventType }
+func (e *UserEvent) AggregateID() string              { return e.aggregateID }
+func (e *UserEvent) Data() interface{}                { return e.data }
 func (e *UserEvent) Metadata() map[string]interface{} { return e.metadata }
 
 // NewUserEvent creates a new user event
@@ -114,7 +114,7 @@ func demonstrateBasicOperations(ctx context.Context, store *postgres.PostgresEve
 			log.Printf("Failed to store event %s: %v", event.ID(), err)
 			continue
 		}
-		logger.Printf("✓ Stored event: %s (%s) for aggregate %s", 
+		logger.Printf("✓ Stored event: %s (%s) for aggregate %s",
 			event.ID(), event.Type(), event.AggregateID())
 	}
 
@@ -134,7 +134,7 @@ func demonstrateBasicOperations(ctx context.Context, store *postgres.PostgresEve
 	} else {
 		logger.Printf("Loaded %d events", len(allEvents))
 		for _, ev := range allEvents {
-			logger.Printf("  - %d: %s (%s)", 
+			logger.Printf("  - %d: %s (%s)",
 				ev.Version.(cursor.IntegerCursor).Seq, ev.Event.Type(), ev.Event.ID())
 		}
 	}
@@ -202,7 +202,7 @@ func demonstrateRealtimeNotifications(ctx context.Context, store *postgres.Realt
 	// Subscribe to events for a specific user stream
 	logger.Println("Subscribing to events for user-charlie...")
 	err := store.SubscribeToStream(demoCtx, "user-charlie", func(payload postgres.NotificationPayload) error {
-		logger.Printf("📢 Stream notification: %s (%s) for %s at version %d", 
+		logger.Printf("📢 Stream notification: %s (%s) for %s at version %d",
 			payload.EventType, payload.ID, payload.AggregateID, payload.Version)
 		streamNotifications <- payload
 		return nil
@@ -215,7 +215,7 @@ func demonstrateRealtimeNotifications(ctx context.Context, store *postgres.Realt
 	// Subscribe to all events
 	logger.Println("Subscribing to all events...")
 	err = store.SubscribeToAll(demoCtx, func(payload postgres.NotificationPayload) error {
-		logger.Printf("🌍 Global notification: %s (%s) for %s on stream %s", 
+		logger.Printf("🌍 Global notification: %s (%s) for %s on stream %s",
 			payload.EventType, payload.ID, payload.AggregateID, payload.StreamName)
 		globalNotifications <- payload
 		return nil
@@ -228,7 +228,7 @@ func demonstrateRealtimeNotifications(ctx context.Context, store *postgres.Realt
 	// Subscribe to events of a specific type
 	logger.Println("Subscribing to UserLoggedOut events...")
 	err = store.SubscribeToEventType(demoCtx, "UserLoggedOut", func(payload postgres.NotificationPayload) error {
-		logger.Printf("🔓 Logout notification: %s (%s) for %s", 
+		logger.Printf("🔓 Logout notification: %s (%s) for %s",
 			payload.EventType, payload.ID, payload.AggregateID)
 		typeNotifications <- payload
 		return nil
@@ -278,9 +278,9 @@ func demonstrateRealtimeNotifications(ctx context.Context, store *postgres.Realt
 	}
 
 	for i, event := range testEvents {
-		logger.Printf("Storing event %d: %s (%s) for %s", 
+		logger.Printf("Storing event %d: %s (%s) for %s",
 			i+1, event.Type(), event.ID(), event.AggregateID())
-		
+
 		err := store.Store(demoCtx, event, cursor.IntegerCursor{Seq: 0})
 		if err != nil {
 			log.Printf("Failed to store event %s: %v", event.ID(), err)
@@ -310,19 +310,19 @@ func demonstrateRealtimeNotifications(ctx context.Context, store *postgres.Realt
 
 	for i := 0; i < 3 && len(streamNotifications) > 0; i++ {
 		notification := <-streamNotifications
-		logger.Printf("  Stream: %s v%d at %v", 
+		logger.Printf("  Stream: %s v%d at %v",
 			notification.EventType, notification.Version, notification.CreatedAt)
 	}
 
 	for i := 0; i < 3 && len(globalNotifications) > 0; i++ {
 		notification := <-globalNotifications
-		logger.Printf("  Global: %s v%d for %s", 
+		logger.Printf("  Global: %s v%d for %s",
 			notification.EventType, notification.Version, notification.AggregateID)
 	}
 
 	for len(typeNotifications) > 0 {
 		notification := <-typeNotifications
-		logger.Printf("  Type: %s v%d for %s", 
+		logger.Printf("  Type: %s v%d for %s",
 			notification.EventType, notification.Version, notification.AggregateID)
 	}
 

--- a/storage/postgres/listener.go
+++ b/storage/postgres/listener.go
@@ -42,7 +42,7 @@ func NewSubscriptionManager() *SubscriptionManager {
 func (sm *SubscriptionManager) Subscribe(channel string, handler EventHandler) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	
+
 	sm.subscriptions[channel] = append(sm.subscriptions[channel], handler)
 }
 
@@ -50,7 +50,7 @@ func (sm *SubscriptionManager) Subscribe(channel string, handler EventHandler) {
 func (sm *SubscriptionManager) Unsubscribe(channel string) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	
+
 	delete(sm.subscriptions, channel)
 }
 
@@ -58,7 +58,7 @@ func (sm *SubscriptionManager) Unsubscribe(channel string) {
 func (sm *SubscriptionManager) GetChannels() []string {
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
-	
+
 	channels := make([]string, 0, len(sm.subscriptions))
 	for channel := range sm.subscriptions {
 		channels = append(channels, channel)
@@ -71,17 +71,17 @@ func (sm *SubscriptionManager) HandleNotification(channel string, payload string
 	sm.mu.RLock()
 	handlers, exists := sm.subscriptions[channel]
 	sm.mu.RUnlock()
-	
+
 	if !exists {
 		return nil // No handlers for this channel
 	}
-	
+
 	// Parse the JSON payload
 	var notificationPayload NotificationPayload
 	if err := json.Unmarshal([]byte(payload), &notificationPayload); err != nil {
 		return fmt.Errorf("failed to parse notification payload: %w", err)
 	}
-	
+
 	// Call all handlers for this channel
 	for _, handler := range handlers {
 		if err := handler(notificationPayload); err != nil {
@@ -90,7 +90,7 @@ func (sm *SubscriptionManager) HandleNotification(channel string, payload string
 			return fmt.Errorf("handler error for channel %s: %w", channel, err)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -98,20 +98,20 @@ func (sm *SubscriptionManager) HandleNotification(channel string, payload string
 type NotificationListener struct {
 	connectionString string
 	logger           *log.Logger
-	
+
 	// Connection management
 	listener *pq.Listener
 	mu       stdSync.RWMutex
 	closed   int32 // atomic
-	
+
 	// Subscription management
 	subscriptions *SubscriptionManager
-	
+
 	// Configuration
 	reconnectInterval    time.Duration
 	maxReconnectAttempts int
 	notificationTimeout  time.Duration
-	
+
 	// Channels for coordination
 	done chan struct{}
 }
@@ -121,21 +121,21 @@ func NewNotificationListener(connectionString string, logger *log.Logger) (*Noti
 	if connectionString == "" {
 		return nil, fmt.Errorf("connection string cannot be empty")
 	}
-	
+
 	if logger == nil {
 		logger = log.New(log.Writer(), "[NotificationListener] ", log.LstdFlags)
 	}
-	
+
 	nl := &NotificationListener{
 		connectionString:     connectionString,
-		logger:              logger,
-		subscriptions:       NewSubscriptionManager(),
-		reconnectInterval:   5 * time.Second,
+		logger:               logger,
+		subscriptions:        NewSubscriptionManager(),
+		reconnectInterval:    5 * time.Second,
 		maxReconnectAttempts: 10,
-		notificationTimeout: 30 * time.Second,
-		done:                make(chan struct{}),
+		notificationTimeout:  30 * time.Second,
+		done:                 make(chan struct{}),
 	}
-	
+
 	// Initialize the pq.Listener
 	nl.listener = pq.NewListener(
 		connectionString,
@@ -143,7 +143,7 @@ func NewNotificationListener(connectionString string, logger *log.Logger) (*Noti
 		nl.notificationTimeout,
 		nl.eventCallback,
 	)
-	
+
 	return nl, nil
 }
 
@@ -180,9 +180,9 @@ func (nl *NotificationListener) Start(ctx context.Context) error {
 	if atomic.LoadInt32(&nl.closed) == 1 {
 		return fmt.Errorf("listener is closed")
 	}
-	
+
 	nl.logger.Printf("Starting notification listener...")
-	
+
 	go nl.listenLoop(ctx)
 	return nil
 }
@@ -190,7 +190,7 @@ func (nl *NotificationListener) Start(ctx context.Context) error {
 // listenLoop is the main loop that processes notifications
 func (nl *NotificationListener) listenLoop(ctx context.Context) {
 	defer nl.logger.Printf("Notification listener stopped")
-	
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -219,9 +219,9 @@ func (nl *NotificationListener) handleNotification(notification *pq.Notification
 	if notification == nil {
 		return
 	}
-	
+
 	nl.logger.Printf("Received notification on channel %s: %s", notification.Channel, notification.Extra)
-	
+
 	if err := nl.subscriptions.HandleNotification(notification.Channel, notification.Extra); err != nil {
 		nl.logger.Printf("Error handling notification: %v", err)
 	}
@@ -232,19 +232,19 @@ func (nl *NotificationListener) SubscribeToStream(aggregateID string, handler Ev
 	if atomic.LoadInt32(&nl.closed) == 1 {
 		return fmt.Errorf("listener is closed")
 	}
-	
+
 	channel := fmt.Sprintf("stream_%s", aggregateID)
-	
+
 	// Add to subscription manager
 	nl.subscriptions.Subscribe(channel, handler)
-	
+
 	// Subscribe to the channel in PostgreSQL
 	if err := nl.listener.Listen(channel); err != nil {
 		// Remove from subscription manager if PostgreSQL subscription failed
 		nl.subscriptions.Unsubscribe(channel)
 		return fmt.Errorf("failed to listen to channel %s: %w", channel, err)
 	}
-	
+
 	nl.logger.Printf("Subscribed to stream: %s", aggregateID)
 	return nil
 }
@@ -254,19 +254,19 @@ func (nl *NotificationListener) SubscribeToAll(handler EventHandler) error {
 	if atomic.LoadInt32(&nl.closed) == 1 {
 		return fmt.Errorf("listener is closed")
 	}
-	
+
 	channel := "events_global"
-	
+
 	// Add to subscription manager
 	nl.subscriptions.Subscribe(channel, handler)
-	
+
 	// Subscribe to the channel in PostgreSQL
 	if err := nl.listener.Listen(channel); err != nil {
 		// Remove from subscription manager if PostgreSQL subscription failed
 		nl.subscriptions.Unsubscribe(channel)
 		return fmt.Errorf("failed to listen to global channel: %w", err)
 	}
-	
+
 	nl.logger.Printf("Subscribed to global events channel")
 	return nil
 }
@@ -277,7 +277,7 @@ func (nl *NotificationListener) SubscribeToEventType(eventType string, handler E
 	if atomic.LoadInt32(&nl.closed) == 1 {
 		return fmt.Errorf("listener is closed")
 	}
-	
+
 	// Create a filtering handler that only processes events of the specified type
 	filteringHandler := func(payload NotificationPayload) error {
 		if payload.EventType == eventType {
@@ -285,22 +285,22 @@ func (nl *NotificationListener) SubscribeToEventType(eventType string, handler E
 		}
 		return nil // Skip events of other types
 	}
-	
+
 	return nl.SubscribeToAll(filteringHandler)
 }
 
 // UnsubscribeFromStream unsubscribes from a specific aggregate stream
 func (nl *NotificationListener) UnsubscribeFromStream(aggregateID string) error {
 	channel := fmt.Sprintf("stream_%s", aggregateID)
-	
+
 	// Remove from subscription manager
 	nl.subscriptions.Unsubscribe(channel)
-	
+
 	// Unsubscribe from the channel in PostgreSQL
 	if err := nl.listener.Unlisten(channel); err != nil {
 		return fmt.Errorf("failed to unlisten from channel %s: %w", channel, err)
 	}
-	
+
 	nl.logger.Printf("Unsubscribed from stream: %s", aggregateID)
 	return nil
 }
@@ -308,15 +308,15 @@ func (nl *NotificationListener) UnsubscribeFromStream(aggregateID string) error 
 // UnsubscribeFromAll unsubscribes from the global events channel
 func (nl *NotificationListener) UnsubscribeFromAll() error {
 	channel := "events_global"
-	
+
 	// Remove from subscription manager
 	nl.subscriptions.Unsubscribe(channel)
-	
+
 	// Unsubscribe from the channel in PostgreSQL
 	if err := nl.listener.Unlisten(channel); err != nil {
 		return fmt.Errorf("failed to unlisten from global channel: %w", err)
 	}
-	
+
 	nl.logger.Printf("Unsubscribed from global events channel")
 	return nil
 }
@@ -331,7 +331,7 @@ func (nl *NotificationListener) IsConnected() bool {
 	if atomic.LoadInt32(&nl.closed) == 1 {
 		return false
 	}
-	
+
 	// Use ping to check connectivity
 	return nl.listener.Ping() == nil
 }
@@ -341,12 +341,12 @@ func (nl *NotificationListener) Close() error {
 	if !atomic.CompareAndSwapInt32(&nl.closed, 0, 1) {
 		return nil // Already closed
 	}
-	
+
 	nl.logger.Printf("Closing notification listener...")
-	
+
 	// Signal the listen loop to stop
 	close(nl.done)
-	
+
 	// Close the pq.Listener
 	if nl.listener != nil {
 		if err := nl.listener.Close(); err != nil {
@@ -354,7 +354,7 @@ func (nl *NotificationListener) Close() error {
 			return err
 		}
 	}
-	
+
 	nl.logger.Printf("Notification listener closed")
 	return nil
 }
@@ -383,7 +383,7 @@ func NewRealtimeEventStore(config *Config) (*RealtimeEventStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return &RealtimeEventStore{
 		PostgresEventStore: store,
 	}, nil
@@ -394,7 +394,7 @@ func (rs *RealtimeEventStore) SubscribeToStream(ctx context.Context, aggregateID
 	if err := rs.listener.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start listener: %w", err)
 	}
-	
+
 	return rs.listener.SubscribeToStream(aggregateID, handler)
 }
 
@@ -403,7 +403,7 @@ func (rs *RealtimeEventStore) SubscribeToAll(ctx context.Context, handler func(N
 	if err := rs.listener.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start listener: %w", err)
 	}
-	
+
 	return rs.listener.SubscribeToAll(handler)
 }
 
@@ -412,7 +412,7 @@ func (rs *RealtimeEventStore) SubscribeToEventType(ctx context.Context, eventTyp
 	if err := rs.listener.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start listener: %w", err)
 	}
-	
+
 	return rs.listener.SubscribeToEventType(eventType, handler)
 }
 

--- a/storage/postgres/store.go
+++ b/storage/postgres/store.go
@@ -101,9 +101,9 @@ type Config struct {
 	ConnMaxIdleTime time.Duration // Default: 15m - Maximum idle time before closing
 
 	// LISTEN/NOTIFY settings for real-time capabilities
-	NotificationTimeout    time.Duration // Default: 30s - Timeout for waiting on notifications
-	ReconnectInterval      time.Duration // Default: 5s - Interval between reconnection attempts
-	MaxReconnectAttempts   int           // Default: 10 - Maximum reconnection attempts before giving up
+	NotificationTimeout  time.Duration // Default: 30s - Timeout for waiting on notifications
+	ReconnectInterval    time.Duration // Default: 5s - Interval between reconnection attempts
+	MaxReconnectAttempts int           // Default: 10 - Maximum reconnection attempts before giving up
 
 	// Performance tuning
 	BatchSize           int  // Default: 1000 - Batch size for bulk operations

--- a/storage/postgres/store_test.go
+++ b/storage/postgres/store_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/c0deZ3R0/go-sync-kit/synckit"
 )
 
+// requirePostgres skips the test unless POSTGRES_TEST=1
+func requirePostgres(t *testing.T) {
+	if os.Getenv("POSTGRES_TEST") != "1" {
+		t.Skip("Skipping Postgres-backed tests; set POSTGRES_TEST=1 to enable")
+	}
+}
+
 // TestEvent is a simple implementation of synckit.Event for testing
 type TestEvent struct {
 	id          string
@@ -20,11 +27,11 @@ type TestEvent struct {
 	metadata    map[string]interface{}
 }
 
-func (e *TestEvent) ID() string                         { return e.id }
-func (e *TestEvent) Type() string                       { return e.eventType }
-func (e *TestEvent) AggregateID() string                { return e.aggregateID }
-func (e *TestEvent) Data() interface{}                  { return e.data }
-func (e *TestEvent) Metadata() map[string]interface{}  { return e.metadata }
+func (e *TestEvent) ID() string                       { return e.id }
+func (e *TestEvent) Type() string                     { return e.eventType }
+func (e *TestEvent) AggregateID() string              { return e.aggregateID }
+func (e *TestEvent) Data() interface{}                { return e.data }
+func (e *TestEvent) Metadata() map[string]interface{} { return e.metadata }
 
 func newTestEvent(id, eventType, aggregateID string, data interface{}) *TestEvent {
 	return &TestEvent{
@@ -48,11 +55,12 @@ func getTestConnectionString() string {
 
 // setupTestStore creates a new PostgresEventStore for testing
 func setupTestStore(t *testing.T) (*PostgresEventStore, func()) {
+	requirePostgres(t)
 	config := &Config{
 		ConnectionString: getTestConnectionString(),
-		Logger:          log.New(os.Stdout, "[TEST] ", log.LstdFlags),
-		MaxOpenConns:    5,
-		MaxIdleConns:    2,
+		Logger:           log.New(os.Stdout, "[TEST] ", log.LstdFlags),
+		MaxOpenConns:     5,
+		MaxIdleConns:     2,
 	}
 
 	store, err := New(config)
@@ -74,6 +82,7 @@ func setupTestStore(t *testing.T) (*PostgresEventStore, func()) {
 }
 
 func TestPostgresEventStore_Store(t *testing.T) {
+	requirePostgres(t)
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -121,6 +130,7 @@ func TestPostgresEventStore_Store(t *testing.T) {
 }
 
 func TestPostgresEventStore_LoadByAggregate(t *testing.T) {
+	requirePostgres(t)
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -158,6 +168,7 @@ func TestPostgresEventStore_LoadByAggregate(t *testing.T) {
 }
 
 func TestPostgresEventStore_StoreBatch(t *testing.T) {
+	requirePostgres(t)
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -196,6 +207,7 @@ func TestPostgresEventStore_StoreBatch(t *testing.T) {
 }
 
 func TestPostgresEventStore_LatestVersion(t *testing.T) {
+	requirePostgres(t)
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -231,15 +243,16 @@ func TestPostgresEventStore_LatestVersion(t *testing.T) {
 }
 
 func TestRealtimeEventStore_Notifications(t *testing.T) {
+	requirePostgres(t)
 	if testing.Short() {
 		t.Skip("Skipping real-time notification test in short mode")
 	}
 
 	config := &Config{
 		ConnectionString: getTestConnectionString(),
-		Logger:          log.New(os.Stdout, "[REALTIME_TEST] ", log.LstdFlags),
-		MaxOpenConns:    5,
-		MaxIdleConns:    2,
+		Logger:           log.New(os.Stdout, "[REALTIME_TEST] ", log.LstdFlags),
+		MaxOpenConns:     5,
+		MaxIdleConns:     2,
 	}
 
 	store, err := NewRealtimeEventStore(config)
@@ -291,15 +304,16 @@ func TestRealtimeEventStore_Notifications(t *testing.T) {
 }
 
 func TestRealtimeEventStore_GlobalNotifications(t *testing.T) {
+	requirePostgres(t)
 	if testing.Short() {
 		t.Skip("Skipping global notification test in short mode")
 	}
 
 	config := &Config{
 		ConnectionString: getTestConnectionString(),
-		Logger:          log.New(os.Stdout, "[GLOBAL_TEST] ", log.LstdFlags),
-		MaxOpenConns:    5,
-		MaxIdleConns:    2,
+		Logger:           log.New(os.Stdout, "[GLOBAL_TEST] ", log.LstdFlags),
+		MaxOpenConns:     5,
+		MaxIdleConns:     2,
 	}
 
 	store, err := NewRealtimeEventStore(config)
@@ -357,12 +371,13 @@ func TestRealtimeEventStore_GlobalNotifications(t *testing.T) {
 }
 
 func TestNotificationListener_ConnectionRecovery(t *testing.T) {
+	requirePostgres(t)
 	if testing.Short() {
 		t.Skip("Skipping connection recovery test in short mode")
 	}
 
 	logger := log.New(os.Stdout, "[RECOVERY_TEST] ", log.LstdFlags)
-	
+
 	listener, err := NewNotificationListener(getTestConnectionString(), logger)
 	if err != nil {
 		t.Fatalf("Failed to create notification listener: %v", err)
@@ -428,8 +443,8 @@ func TestNotificationListener_ConnectionRecovery(t *testing.T) {
 func BenchmarkPostgresEventStore_Store(b *testing.B) {
 	config := &Config{
 		ConnectionString: getTestConnectionString(),
-		MaxOpenConns:    10,
-		MaxIdleConns:    5,
+		MaxOpenConns:     10,
+		MaxIdleConns:     5,
 	}
 
 	store, err := New(config)
@@ -448,7 +463,7 @@ func BenchmarkPostgresEventStore_Store(b *testing.B) {
 			"bench-aggregate",
 			map[string]int{"iteration": i},
 		)
-		
+
 		err := store.Store(ctx, event, cursor.IntegerCursor{Seq: 0})
 		if err != nil {
 			b.Fatalf("Failed to store event: %v", err)
@@ -459,8 +474,8 @@ func BenchmarkPostgresEventStore_Store(b *testing.B) {
 func BenchmarkPostgresEventStore_Load(b *testing.B) {
 	config := &Config{
 		ConnectionString: getTestConnectionString(),
-		MaxOpenConns:    10,
-		MaxIdleConns:    5,
+		MaxOpenConns:     10,
+		MaxIdleConns:     5,
 	}
 
 	store, err := New(config)
@@ -479,7 +494,7 @@ func BenchmarkPostgresEventStore_Load(b *testing.B) {
 			"bench-load-aggregate",
 			map[string]int{"iteration": i},
 		)
-		
+
 		err := store.Store(ctx, event, cursor.IntegerCursor{Seq: 0})
 		if err != nil {
 			b.Fatalf("Failed to store setup event: %v", err)

--- a/storage/sqlite/store.go
+++ b/storage/sqlite/store.go
@@ -26,12 +26,12 @@ import (
 
 // Operation constants for consistent error reporting
 const (
-	opStore         = "sqlite.Store"
-	opStoreBatch    = "sqlite.StoreBatch"
-	opLoad          = "sqlite.Load"
+	opStore           = "sqlite.Store"
+	opStoreBatch      = "sqlite.StoreBatch"
+	opLoad            = "sqlite.Load"
 	opLoadByAggregate = "sqlite.LoadByAggregate"
-	opLatestVersion = "sqlite.LatestVersion"
-	opParseVersion  = "sqlite.ParseVersion"
+	opLatestVersion   = "sqlite.LatestVersion"
+	opParseVersion    = "sqlite.ParseVersion"
 )
 
 // Custom errors for better error handling

--- a/storage/sqlite/store_integration_test.go
+++ b/storage/sqlite/store_integration_test.go
@@ -220,7 +220,7 @@ func TestSQLiteEventStore_WALAndPoolDefaults(t *testing.T) {
 			{"journal_mode", "PRAGMA journal_mode;", "wal"},
 			{"busy_timeout", "PRAGMA busy_timeout;", 5000},
 			{"synchronous", "PRAGMA synchronous;", 1}, // NORMAL = 1
-			{"temp_store", "PRAGMA temp_store;", 2},    // MEMORY = 2
+			{"temp_store", "PRAGMA temp_store;", 2},   // MEMORY = 2
 			{"cache_size", "PRAGMA cache_size;", -20000},
 		}
 
@@ -292,7 +292,7 @@ func TestSQLiteEventStore_PragmaErrorHandling(t *testing.T) {
 		_, err := New(config)
 		assert.Error(t, err, "Should fail with invalid data source")
 		// Error could be either from database opening or PRAGMA application
-		assert.True(t, 
+		assert.True(t,
 			strings.Contains(err.Error(), "failed to open sqlite database") ||
 				strings.Contains(err.Error(), "failed to apply PRAGMA settings"),
 			"Error should mention database opening or PRAGMA application")

--- a/storage/sqlite/wal_benchmark_test.go
+++ b/storage/sqlite/wal_benchmark_test.go
@@ -16,11 +16,11 @@ import (
 // as mentioned in the code review
 func BenchmarkSQLiteWALConcurrentReadWrite(b *testing.B) {
 	scenarios := []struct {
-		name        string
-		numReaders  int
-		numWriters  int
-		enableWAL   bool
-		batchSize   int
+		name       string
+		numReaders int
+		numWriters int
+		enableWAL  bool
+		batchSize  int
 	}{
 		{"WAL_1Reader_1Writer", 1, 1, true, 10},
 		{"WAL_2Readers_1Writer", 2, 1, true, 10},
@@ -30,7 +30,7 @@ func BenchmarkSQLiteWALConcurrentReadWrite(b *testing.B) {
 		{"NoWAL_1Reader_1Writer", 1, 1, false, 10},
 		{"NoWAL_2Readers_1Writer", 2, 1, false, 10},
 	}
-	
+
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, func(b *testing.B) {
 			benchmarkConcurrentReadWrite(b, scenario.numReaders, scenario.numWriters, scenario.enableWAL, scenario.batchSize)
@@ -41,7 +41,7 @@ func BenchmarkSQLiteWALConcurrentReadWrite(b *testing.B) {
 func benchmarkConcurrentReadWrite(b *testing.B, numReaders, numWriters int, enableWAL bool, batchSize int) {
 	tempDir := b.TempDir()
 	dbPath := filepath.Join(tempDir, "benchmark.db")
-	
+
 	config := &Config{
 		DataSourceName:  dbPath,
 		EnableWAL:       enableWAL,
@@ -50,15 +50,15 @@ func benchmarkConcurrentReadWrite(b *testing.B, numReaders, numWriters int, enab
 		ConnMaxLifetime: time.Hour,
 		ConnMaxIdleTime: 5 * time.Minute,
 	}
-	
+
 	store, err := New(config)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer store.Close()
-	
+
 	ctx := context.Background()
-	
+
 	// Pre-populate some data for readers
 	for i := 0; i < 100; i++ {
 		event := &MockEvent{
@@ -72,12 +72,12 @@ func benchmarkConcurrentReadWrite(b *testing.B, numReaders, numWriters int, enab
 			b.Fatal(err)
 		}
 	}
-	
+
 	b.ResetTimer()
-	
+
 	var wg sync.WaitGroup
 	startTime := time.Now()
-	
+
 	// Start readers
 	for r := 0; r < numReaders; r++ {
 		wg.Add(1)
@@ -86,7 +86,7 @@ func benchmarkConcurrentReadWrite(b *testing.B, numReaders, numWriters int, enab
 			benchmarkReader(b, store, readerID, startTime)
 		}(r)
 	}
-	
+
 	// Start writers
 	for w := 0; w < numWriters; w++ {
 		wg.Add(1)
@@ -95,14 +95,14 @@ func benchmarkConcurrentReadWrite(b *testing.B, numReaders, numWriters int, enab
 			benchmarkWriter(b, store, writerID, batchSize, startTime)
 		}(w)
 	}
-	
+
 	wg.Wait()
 }
 
 func benchmarkReader(b *testing.B, store *SQLiteEventStore, readerID int, startTime time.Time) {
 	ctx := context.Background()
 	readCount := 0
-	
+
 	for time.Since(startTime) < time.Duration(b.N)*time.Nanosecond {
 		// Perform different types of reads
 		switch readCount % 3 {
@@ -136,12 +136,12 @@ func benchmarkReader(b *testing.B, store *SQLiteEventStore, readerID int, startT
 func benchmarkWriter(b *testing.B, store *SQLiteEventStore, writerID int, batchSize int, startTime time.Time) {
 	ctx := context.Background()
 	writeCount := 0
-	
+
 	for time.Since(startTime) < time.Duration(b.N)*time.Nanosecond {
 		// Create batch of events
 		events := make([]synckit.EventWithVersion, batchSize)
 		baseSeq := uint64(writeCount*batchSize + writerID*1000000) // Avoid sequence conflicts
-		
+
 		for i := 0; i < batchSize; i++ {
 			events[i] = synckit.EventWithVersion{
 				Event: &MockEvent{
@@ -149,24 +149,24 @@ func benchmarkWriter(b *testing.B, store *SQLiteEventStore, writerID int, batchS
 					eventType:   "BenchmarkEvent",
 					aggregateID: fmt.Sprintf("benchmark-agg-%d", (writeCount*batchSize+i)%25),
 					data: map[string]interface{}{
-						"writer_id":   writerID,
-						"batch_id":    writeCount,
-						"event_id":    i,
-						"timestamp":   time.Now().Unix(),
-						"payload":     fmt.Sprintf("Benchmark payload for writer %d batch %d event %d", writerID, writeCount, i),
+						"writer_id": writerID,
+						"batch_id":  writeCount,
+						"event_id":  i,
+						"timestamp": time.Now().Unix(),
+						"payload":   fmt.Sprintf("Benchmark payload for writer %d batch %d event %d", writerID, writeCount, i),
 					},
 				},
 				Version: cursor.IntegerCursor{Seq: baseSeq + uint64(i)},
 			}
 		}
-		
+
 		// Write batch
 		err := store.StoreBatch(ctx, events)
 		if err != nil {
 			b.Error(err)
 			return
 		}
-		
+
 		writeCount++
 	}
 }
@@ -184,7 +184,7 @@ func BenchmarkSQLiteWALScaling(b *testing.B) {
 		{"Conns_50_10", 50, 10},
 		{"Conns_100_20", 100, 20},
 	}
-	
+
 	for _, connConfig := range connectionConfigs {
 		b.Run(connConfig.name, func(b *testing.B) {
 			benchmarkWALScaling(b, connConfig.maxOpenConns, connConfig.maxIdleConns)
@@ -195,7 +195,7 @@ func BenchmarkSQLiteWALScaling(b *testing.B) {
 func benchmarkWALScaling(b *testing.B, maxOpenConns, maxIdleConns int) {
 	tempDir := b.TempDir()
 	dbPath := filepath.Join(tempDir, "scaling.db")
-	
+
 	config := &Config{
 		DataSourceName:  dbPath,
 		EnableWAL:       true,
@@ -204,18 +204,18 @@ func benchmarkWALScaling(b *testing.B, maxOpenConns, maxIdleConns int) {
 		ConnMaxLifetime: time.Hour,
 		ConnMaxIdleTime: 5 * time.Minute,
 	}
-	
+
 	store, err := New(config)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer store.Close()
-	
+
 	ctx := context.Background()
-	
+
 	b.ResetTimer()
 	b.SetBytes(1024) // Approximate size per operation
-	
+
 	b.RunParallel(func(pb *testing.PB) {
 		eventCounter := 0
 		for pb.Next() {
@@ -225,7 +225,7 @@ func benchmarkWALScaling(b *testing.B, maxOpenConns, maxIdleConns int) {
 				aggregateID: fmt.Sprintf("scaling-agg-%d", eventCounter%10),
 				data:        fmt.Sprintf("Scaling test data for event %d with max connections %d", eventCounter, maxOpenConns),
 			}
-			
+
 			err := store.Store(ctx, event, cursor.IntegerCursor{Seq: uint64(eventCounter + 1)})
 			if err != nil {
 				b.Error(err)
@@ -239,7 +239,7 @@ func benchmarkWALScaling(b *testing.B, maxOpenConns, maxIdleConns int) {
 // BenchmarkSQLiteWALTransactionSizes benchmarks different transaction sizes in WAL mode
 func BenchmarkSQLiteWALTransactionSizes(b *testing.B) {
 	transactionSizes := []int{1, 5, 10, 25, 50, 100, 250}
-	
+
 	for _, txSize := range transactionSizes {
 		b.Run(fmt.Sprintf("TxSize_%d", txSize), func(b *testing.B) {
 			benchmarkWALTransactionSize(b, txSize)
@@ -250,26 +250,26 @@ func BenchmarkSQLiteWALTransactionSizes(b *testing.B) {
 func benchmarkWALTransactionSize(b *testing.B, transactionSize int) {
 	tempDir := b.TempDir()
 	dbPath := filepath.Join(tempDir, "transaction.db")
-	
+
 	config := DefaultConfig(dbPath)
 	config.EnableWAL = true
-	
+
 	store, err := New(config)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer store.Close()
-	
+
 	ctx := context.Background()
-	
+
 	b.ResetTimer()
 	b.SetBytes(int64(transactionSize * 512)) // Approximate bytes per transaction
-	
+
 	for i := 0; i < b.N; i++ {
 		// Create batch of events
 		events := make([]synckit.EventWithVersion, transactionSize)
 		baseSeq := uint64(i * transactionSize)
-		
+
 		for j := 0; j < transactionSize; j++ {
 			events[j] = synckit.EventWithVersion{
 				Event: &MockEvent{
@@ -281,7 +281,7 @@ func benchmarkWALTransactionSize(b *testing.B, transactionSize int) {
 				Version: cursor.IntegerCursor{Seq: baseSeq + uint64(j)},
 			}
 		}
-		
+
 		// Store batch in single transaction
 		err := store.StoreBatch(ctx, events)
 		if err != nil {
@@ -293,16 +293,16 @@ func benchmarkWALTransactionSize(b *testing.B, transactionSize int) {
 // BenchmarkSQLiteWALCheckpointBehavior benchmarks behavior around WAL checkpoint operations
 func BenchmarkSQLiteWALCheckpointBehavior(b *testing.B) {
 	scenarios := []struct {
-		name              string
-		eventsBeforeRead  int
-		readFrequency     int
-		checkpointFreq    int
+		name             string
+		eventsBeforeRead int
+		readFrequency    int
+		checkpointFreq   int
 	}{
 		{"Frequent_Checkpoints", 1000, 50, 100},
 		{"Moderate_Checkpoints", 2000, 100, 500},
 		{"Infrequent_Checkpoints", 5000, 250, 1000},
 	}
-	
+
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, func(b *testing.B) {
 			benchmarkWALCheckpointBehavior(b, scenario.eventsBeforeRead, scenario.readFrequency, scenario.checkpointFreq)
@@ -313,18 +313,18 @@ func BenchmarkSQLiteWALCheckpointBehavior(b *testing.B) {
 func benchmarkWALCheckpointBehavior(b *testing.B, eventsBeforeRead, readFrequency, checkpointFreq int) {
 	tempDir := b.TempDir()
 	dbPath := filepath.Join(tempDir, "checkpoint.db")
-	
+
 	config := DefaultConfig(dbPath)
 	config.EnableWAL = true
-	
+
 	store, err := New(config)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer store.Close()
-	
+
 	ctx := context.Background()
-	
+
 	// Pre-populate to simulate realistic WAL size
 	for i := 0; i < eventsBeforeRead; i++ {
 		event := &MockEvent{
@@ -338,9 +338,9 @@ func benchmarkWALCheckpointBehavior(b *testing.B, eventsBeforeRead, readFrequenc
 			b.Fatal(err)
 		}
 	}
-	
+
 	b.ResetTimer()
-	
+
 	for i := 0; i < b.N; i++ {
 		// Write an event
 		event := &MockEvent{
@@ -349,12 +349,12 @@ func benchmarkWALCheckpointBehavior(b *testing.B, eventsBeforeRead, readFrequenc
 			aggregateID: fmt.Sprintf("checkpoint-agg-%d", i%25),
 			data:        fmt.Sprintf("Checkpoint benchmark data %d", i),
 		}
-		
+
 		err := store.Store(ctx, event, cursor.IntegerCursor{Seq: uint64(eventsBeforeRead + i + 1)})
 		if err != nil {
 			b.Fatal(err)
 		}
-		
+
 		// Periodic reads
 		if i%readFrequency == 0 {
 			_, err := store.Load(ctx, cursor.IntegerCursor{Seq: uint64(eventsBeforeRead + i - readFrequency/2)})
@@ -362,7 +362,7 @@ func benchmarkWALCheckpointBehavior(b *testing.B, eventsBeforeRead, readFrequenc
 				b.Fatal(err)
 			}
 		}
-		
+
 		// Simulate checkpoint behavior (SQLite handles this automatically, but we can trigger reads that might be affected)
 		if i%checkpointFreq == 0 {
 			// Perform a larger read operation that might benefit from checkpointing
@@ -386,13 +386,13 @@ func BenchmarkSQLiteWALReadPerformance(b *testing.B) {
 		{"AggregateReads", benchmarkAggregateReads},
 		{"RangeReads", benchmarkRangeReads},
 	}
-	
+
 	for _, datasetSize := range datasetSizes {
 		for _, pattern := range readPatterns {
 			b.Run(fmt.Sprintf("%s_Dataset_%d", pattern.name, datasetSize), func(b *testing.B) {
 				store := setupWALStoreWithData(b, datasetSize)
 				defer store.Close()
-				
+
 				b.ResetTimer()
 				pattern.fn(b, store, datasetSize)
 			})
@@ -403,17 +403,17 @@ func BenchmarkSQLiteWALReadPerformance(b *testing.B) {
 func setupWALStoreWithData(b *testing.B, datasetSize int) *SQLiteEventStore {
 	tempDir := b.TempDir()
 	dbPath := filepath.Join(tempDir, "read_perf.db")
-	
+
 	config := DefaultConfig(dbPath)
 	config.EnableWAL = true
-	
+
 	store, err := New(config)
 	if err != nil {
 		b.Fatal(err)
 	}
-	
+
 	ctx := context.Background()
-	
+
 	// Populate with test data
 	events := make([]synckit.EventWithVersion, datasetSize)
 	for i := 0; i < datasetSize; i++ {
@@ -433,19 +433,19 @@ func setupWALStoreWithData(b *testing.B, datasetSize int) *SQLiteEventStore {
 			Version: cursor.IntegerCursor{Seq: uint64(i + 1)},
 		}
 	}
-	
+
 	// Use batch insert for better performance during setup
 	err = store.StoreBatch(ctx, events)
 	if err != nil {
 		b.Fatal(err)
 	}
-	
+
 	return store
 }
 
 func benchmarkSequentialReads(b *testing.B, store *SQLiteEventStore, datasetSize int) {
 	ctx := context.Background()
-	
+
 	for i := 0; i < b.N; i++ {
 		startSeq := uint64((i % (datasetSize / 10)) * 10)
 		_, err := store.Load(ctx, cursor.IntegerCursor{Seq: startSeq})
@@ -457,7 +457,7 @@ func benchmarkSequentialReads(b *testing.B, store *SQLiteEventStore, datasetSize
 
 func benchmarkRandomReads(b *testing.B, store *SQLiteEventStore, datasetSize int) {
 	ctx := context.Background()
-	
+
 	for i := 0; i < b.N; i++ {
 		randomSeq := uint64((i * 7919) % datasetSize) // Pseudo-random access
 		_, err := store.Load(ctx, cursor.IntegerCursor{Seq: randomSeq})
@@ -469,7 +469,7 @@ func benchmarkRandomReads(b *testing.B, store *SQLiteEventStore, datasetSize int
 
 func benchmarkAggregateReads(b *testing.B, store *SQLiteEventStore, datasetSize int) {
 	ctx := context.Background()
-	
+
 	for i := 0; i < b.N; i++ {
 		aggregateID := fmt.Sprintf("read-perf-agg-%d", i%100)
 		_, err := store.LoadByAggregate(ctx, aggregateID, cursor.IntegerCursor{Seq: 0})
@@ -481,7 +481,7 @@ func benchmarkAggregateReads(b *testing.B, store *SQLiteEventStore, datasetSize 
 
 func benchmarkRangeReads(b *testing.B, store *SQLiteEventStore, datasetSize int) {
 	ctx := context.Background()
-	
+
 	for i := 0; i < b.N; i++ {
 		startSeq := uint64((i % (datasetSize / 100)) * 100)
 		_, err := store.Load(ctx, cursor.IntegerCursor{Seq: startSeq})

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,26 +7,26 @@ import (
 
 // Common storage errors
 var (
-	ErrKeyNotFound    = errors.New("key not found")
-	ErrStorageClosed  = errors.New("storage is closed")
-	ErrInvalidKey     = errors.New("invalid key")
-	ErrInvalidValue   = errors.New("invalid value")
+	ErrKeyNotFound   = errors.New("key not found")
+	ErrStorageClosed = errors.New("storage is closed")
+	ErrInvalidKey    = errors.New("invalid key")
+	ErrInvalidValue  = errors.New("invalid value")
 )
 
 // Storage defines the interface for storage backends.
 type Storage interface {
 	// Get retrieves data for the given key.
 	Get(ctx context.Context, key string) ([]byte, error)
-	
+
 	// Put stores data for the given key.
 	Put(ctx context.Context, key string, value []byte) error
-	
+
 	// Delete removes the data for the given key.
 	Delete(ctx context.Context, key string) error
-	
+
 	// Exists checks if a key exists in storage.
 	Exists(ctx context.Context, key string) (bool, error)
-	
+
 	// Close closes the storage backend.
 	Close() error
 }
@@ -51,18 +51,18 @@ func (m *MemoryStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	if key == "" {
 		return nil, ErrInvalidKey
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	default:
 	}
-	
+
 	value, exists := m.data[key]
 	if !exists {
 		return nil, ErrKeyNotFound
 	}
-	
+
 	// Return a copy to prevent modification
 	result := make([]byte, len(value))
 	copy(result, value)
@@ -79,13 +79,13 @@ func (m *MemoryStorage) Put(ctx context.Context, key string, value []byte) error
 	if value == nil {
 		return ErrInvalidValue
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	
+
 	// Store a copy to prevent modification
 	stored := make([]byte, len(value))
 	copy(stored, value)
@@ -100,13 +100,13 @@ func (m *MemoryStorage) Delete(ctx context.Context, key string) error {
 	if key == "" {
 		return ErrInvalidKey
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	
+
 	delete(m.data, key)
 	return nil
 }
@@ -118,13 +118,13 @@ func (m *MemoryStorage) Exists(ctx context.Context, key string) (bool, error) {
 	if key == "" {
 		return false, ErrInvalidKey
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return false, ctx.Err()
 	default:
 	}
-	
+
 	_, exists := m.data[key]
 	return exists, nil
 }

--- a/synckit/advanced_patterns_test.go
+++ b/synckit/advanced_patterns_test.go
@@ -13,7 +13,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			WithDescription("Test group for unit tests"),
 			WithEnabled(true),
 		)
-		
+
 		// Test basic properties
 		if group.Name != "test-group" {
 			t.Errorf("Expected name 'test-group', got %s", group.Name)
@@ -24,7 +24,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 		if !group.IsEnabled() {
 			t.Errorf("Group should be enabled")
 		}
-		
+
 		// Test adding rules
 		rule := Rule{
 			Name:     "test-rule",
@@ -32,7 +32,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Resolver: &LastWriteWinsResolver{},
 		}
 		group.AddRule(rule)
-		
+
 		rules := group.GetAllRules()
 		if len(rules) != 1 {
 			t.Fatalf("Expected 1 rule, got %d", len(rules))
@@ -41,7 +41,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			t.Errorf("Expected namespaced rule name 'test-group.test-rule', got %s", rules[0].Name)
 		}
 	})
-	
+
 	t.Run("RuleGroup_NestedHierarchy", func(t *testing.T) {
 		// Create parent group
 		parent := NewRuleGroup("parent")
@@ -50,7 +50,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Matcher:  EventTypeIs("ParentEvent"),
 			Resolver: &LastWriteWinsResolver{},
 		})
-		
+
 		// Create child group
 		child := NewRuleGroup("child")
 		child.AddRule(Rule{
@@ -58,16 +58,16 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Matcher:  EventTypeIs("ChildEvent"),
 			Resolver: &AdditiveMergeResolver{},
 		})
-		
+
 		// Add child to parent
 		parent.AddSubGroup(child)
-		
+
 		// Test hierarchy
 		allRules := parent.GetAllRules()
 		if len(allRules) != 2 {
 			t.Fatalf("Expected 2 rules total, got %d", len(allRules))
 		}
-		
+
 		// Check namespacing
 		expectedNames := []string{"parent.parent-rule", "parent.child.child-rule"}
 		for i, rule := range allRules {
@@ -75,7 +75,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 				t.Errorf("Expected rule name %s, got %s", expectedNames[i], rule.Name)
 			}
 		}
-		
+
 		// Test stats
 		stats := parent.GetStats()
 		if stats.RuleCount != 1 {
@@ -88,7 +88,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			t.Errorf("Expected total rules 2, got %d", stats.TotalRules)
 		}
 	})
-	
+
 	t.Run("CompositeResolver_GroupResolution", func(t *testing.T) {
 		// Create groups
 		userGroup := NewRuleGroup("users")
@@ -97,20 +97,20 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Matcher:  EventTypeIs("UserUpdated"),
 			Resolver: &LastWriteWinsResolver{},
 		})
-		
+
 		orderGroup := NewRuleGroup("orders")
 		orderGroup.AddRule(Rule{
 			Name:     "order-merge",
 			Matcher:  EventTypeIs("OrderCreated"),
 			Resolver: &AdditiveMergeResolver{},
 		})
-		
+
 		// Create composite resolver
 		composite := NewCompositeResolver(&ManualReviewResolver{},
 			WithCompositeLogger(&mockLogger{}),
 		)
 		composite.AddGroup(userGroup).AddGroup(orderGroup)
-		
+
 		// Test user event resolution
 		userConflict := Conflict{
 			EventType:   "UserUpdated",
@@ -119,7 +119,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Remote:      EventWithVersion{Event: &testEvent{eventType: "UserUpdated"}, Version: &testVersion{v: 2}},
 			Metadata:    make(map[string]any),
 		}
-		
+
 		resolved, err := composite.Resolve(context.Background(), userConflict)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -127,7 +127,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 		if resolved.Decision != "keep_remote" {
 			t.Errorf("Expected LWW decision 'keep_remote', got %s", resolved.Decision)
 		}
-		
+
 		// Test order event resolution
 		orderConflict := Conflict{
 			EventType:   "OrderCreated",
@@ -136,7 +136,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Remote:      EventWithVersion{Event: &testEvent{eventType: "OrderCreated"}, Version: &testVersion{v: 2}},
 			Metadata:    make(map[string]any),
 		}
-		
+
 		resolved, err = composite.Resolve(context.Background(), orderConflict)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -144,7 +144,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 		if resolved.Decision != "merge" {
 			t.Errorf("Expected merge decision 'merge', got %s", resolved.Decision)
 		}
-		
+
 		// Test fallback for unknown event
 		unknownConflict := Conflict{
 			EventType:   "UnknownEvent",
@@ -153,7 +153,7 @@ func TestAdvancedCompositePattern(t *testing.T) {
 			Remote:      EventWithVersion{Event: &testEvent{eventType: "UnknownEvent"}, Version: &testVersion{v: 2}},
 			Metadata:    make(map[string]any),
 		}
-		
+
 		resolved, err = composite.Resolve(context.Background(), unknownConflict)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -168,7 +168,7 @@ func TestAdvancedMementoPattern(t *testing.T) {
 	t.Run("InMemoryMementoCaretaker_BasicOperations", func(t *testing.T) {
 		caretaker := NewInMemoryMementoCaretaker()
 		ctx := context.Background()
-		
+
 		// Create test memento
 		memento := &ResolutionMemento{
 			ID:        "test-memento-1",
@@ -184,18 +184,18 @@ func TestAdvancedMementoPattern(t *testing.T) {
 			ResolverName: "TestResolver",
 			UserID:       "user123",
 		}
-		
+
 		// Test save and get
 		err := caretaker.Save(ctx, memento)
 		if err != nil {
 			t.Fatalf("Expected no error saving memento, got %v", err)
 		}
-		
+
 		retrieved, err := caretaker.Get(ctx, "test-memento-1")
 		if err != nil {
 			t.Fatalf("Expected no error getting memento, got %v", err)
 		}
-		
+
 		if retrieved.ID != memento.ID {
 			t.Errorf("Expected ID %s, got %s", memento.ID, retrieved.ID)
 		}
@@ -203,12 +203,12 @@ func TestAdvancedMementoPattern(t *testing.T) {
 			t.Errorf("Expected UserID user123, got %s", retrieved.UserID)
 		}
 	})
-	
+
 	t.Run("AuditableResolver_Integration", func(t *testing.T) {
 		caretaker := NewInMemoryMementoCaretaker()
 		baseResolver := &LastWriteWinsResolver{}
 		logger := &mockLogger{}
-		
+
 		auditableResolver := NewAuditableResolver(baseResolver, caretaker,
 			WithAuditLogger(logger),
 			WithUserIDExtractor(func(ctx context.Context) string {
@@ -218,10 +218,10 @@ func TestAdvancedMementoPattern(t *testing.T) {
 				return ""
 			}),
 		)
-		
+
 		// Create context with user ID
 		ctx := context.WithValue(context.Background(), "user_id", "test-user")
-		
+
 		// Create test conflict
 		conflict := Conflict{
 			EventType:   "TestEvent",
@@ -230,29 +230,28 @@ func TestAdvancedMementoPattern(t *testing.T) {
 			Remote:      EventWithVersion{Event: &testEvent{eventType: "TestEvent"}, Version: &testVersion{v: 2}},
 			Metadata:    make(map[string]any),
 		}
-		
+
 		// Resolve conflict
 		resolved, err := auditableResolver.Resolve(ctx, conflict)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		
+
 		// Verify resolution worked
 		if resolved.Decision != "keep_remote" {
 			t.Errorf("Expected decision 'keep_remote', got %s", resolved.Decision)
 		}
-		
+
 		// Check audit trail
 		trail, err := auditableResolver.GetAuditTrail(ctx, "test-aggregate")
 		if err != nil {
 			t.Fatalf("Expected no error getting audit trail, got %v", err)
 		}
-		
-		
+
 		if len(trail) != 1 {
 			t.Fatalf("Expected 1 audit entry, got %d", len(trail))
 		}
-		
+
 		entry := trail[0]
 		if entry.UserID != "test-user" {
 			t.Errorf("Expected UserID 'test-user', got %s", entry.UserID)
@@ -261,12 +260,12 @@ func TestAdvancedMementoPattern(t *testing.T) {
 			t.Errorf("Expected AggregateID 'test-aggregate', got %s", entry.AggregateID)
 		}
 	})
-	
+
 	t.Run("RollbackCapability_Analysis", func(t *testing.T) {
 		caretaker := NewInMemoryMementoCaretaker()
 		rollback := NewRollbackCapability(caretaker)
 		ctx := context.Background()
-		
+
 		// Create multiple mementos for the same aggregate
 		baseTime := time.Now()
 		mementos := []*ResolutionMemento{
@@ -276,7 +275,7 @@ func TestAdvancedMementoPattern(t *testing.T) {
 				AggregateID: "agg-1",
 			},
 			{
-				ID:          "memento-2", 
+				ID:          "memento-2",
 				Timestamp:   baseTime.Add(1 * time.Minute),
 				AggregateID: "agg-1",
 			},
@@ -286,18 +285,18 @@ func TestAdvancedMementoPattern(t *testing.T) {
 				AggregateID: "agg-1",
 			},
 		}
-		
+
 		// Save all mementos
 		for _, memento := range mementos {
 			caretaker.Save(ctx, memento)
 		}
-		
+
 		// Analyze rollback for first memento
 		analysis, err := rollback.AnalyzeRollback(ctx, "memento-1")
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		
+
 		if analysis.TargetMemento.ID != "memento-1" {
 			t.Errorf("Expected target memento ID 'memento-1', got %s", analysis.TargetMemento.ID)
 		}
@@ -317,12 +316,12 @@ func TestAdvancedObserverPattern(t *testing.T) {
 	t.Run("ObservableResolver_BasicMetrics", func(t *testing.T) {
 		collector := &mockExtendedMetricsCollector{}
 		baseResolver := &LastWriteWinsResolver{}
-		
+
 		observableResolver := NewObservableResolver(baseResolver,
 			WithMetricsCollector(collector),
 			WithGroupName("test-group"),
 		)
-		
+
 		// Create test conflict
 		conflict := Conflict{
 			EventType:   "TestEvent",
@@ -331,23 +330,23 @@ func TestAdvancedObserverPattern(t *testing.T) {
 			Remote:      EventWithVersion{Event: &testEvent{eventType: "TestEvent"}, Version: &testVersion{v: 2}},
 			Metadata:    make(map[string]any),
 		}
-		
+
 		// Resolve conflict
 		resolved, err := observableResolver.Resolve(context.Background(), conflict)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		
+
 		// Verify resolution worked
 		if resolved.Decision != "keep_remote" {
 			t.Errorf("Expected decision 'keep_remote', got %s", resolved.Decision)
 		}
-		
+
 		// Verify metrics were collected
 		if len(collector.resolutions) != 1 {
 			t.Fatalf("Expected 1 resolution metric, got %d", len(collector.resolutions))
 		}
-		
+
 		metric := collector.resolutions[0]
 		if metric.GroupName != "test-group" {
 			t.Errorf("Expected group name 'test-group', got %s", metric.GroupName)
@@ -359,7 +358,7 @@ func TestAdvancedObserverPattern(t *testing.T) {
 			t.Errorf("Expected success to be true")
 		}
 	})
-	
+
 	t.Run("ObservableResolver_WithHooks", func(t *testing.T) {
 		var hookCalls []string
 		hooks := &ResolutionHooks{
@@ -370,11 +369,11 @@ func TestAdvancedObserverPattern(t *testing.T) {
 				hookCalls = append(hookCalls, fmt.Sprintf("resolution-%s", result.Decision))
 			},
 		}
-		
+
 		observableResolver := NewObservableResolver(&LastWriteWinsResolver{},
 			WithResolutionHooks(hooks),
 		)
-		
+
 		conflict := Conflict{
 			EventType:   "TestEvent",
 			AggregateID: "hook-test",
@@ -382,12 +381,12 @@ func TestAdvancedObserverPattern(t *testing.T) {
 			Remote:      EventWithVersion{Event: &testEvent{eventType: "TestEvent"}, Version: &testVersion{v: 2}},
 			Metadata:    make(map[string]any),
 		}
-		
+
 		_, err := observableResolver.Resolve(context.Background(), conflict)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		
+
 		// Verify hooks were called
 		if len(hookCalls) != 2 {
 			t.Fatalf("Expected 2 hook calls, got %d", len(hookCalls))
@@ -409,11 +408,11 @@ type testEvent struct {
 	data        interface{}
 }
 
-func (e *testEvent) ID() string                         { return e.id }
-func (e *testEvent) Type() string                       { return e.eventType }
-func (e *testEvent) AggregateID() string                { return e.aggregateID }
-func (e *testEvent) Data() interface{}                  { return e.data }
-func (e *testEvent) Metadata() map[string]interface{}   { return nil }
+func (e *testEvent) ID() string                       { return e.id }
+func (e *testEvent) Type() string                     { return e.eventType }
+func (e *testEvent) AggregateID() string              { return e.aggregateID }
+func (e *testEvent) Data() interface{}                { return e.data }
+func (e *testEvent) Metadata() map[string]interface{} { return nil }
 
 type testVersion struct {
 	v int
@@ -421,20 +420,27 @@ type testVersion struct {
 
 func (v *testVersion) String() string { return fmt.Sprintf("v%d", v.v) }
 func (v *testVersion) Compare(other Version) int {
-	if other == nil { return 1 }
+	if other == nil {
+		return 1
+	}
 	if otherV, ok := other.(*testVersion); ok {
-		if v.v < otherV.v { return -1 }
-		if v.v > otherV.v { return 1 }
+		if v.v < otherV.v {
+			return -1
+		}
+		if v.v > otherV.v {
+			return 1
+		}
 		return 0
 	}
 	return 0
 }
 func (v *testVersion) IsZero() bool { return v.v == 0 }
 
-type mockLogger struct{
+type mockLogger struct {
 	errorMessages []string
 	debugMessages []string
 }
+
 func (l *mockLogger) Debug(msg string, args ...interface{}) {
 	l.debugMessages = append(l.debugMessages, fmt.Sprintf(msg, args...))
 }
@@ -455,19 +461,19 @@ type mockExtendedMetricsCollector struct {
 }
 
 func (c *mockExtendedMetricsCollector) RecordSyncDuration(op string, dur time.Duration) {}
-func (c *mockExtendedMetricsCollector) RecordSyncEvents(pushed, pulled int) {}
-func (c *mockExtendedMetricsCollector) RecordConflicts(count int) {}
-func (c *mockExtendedMetricsCollector) RecordSyncErrors(op, errType string) {}
+func (c *mockExtendedMetricsCollector) RecordSyncEvents(pushed, pulled int)             {}
+func (c *mockExtendedMetricsCollector) RecordConflicts(count int)                       {}
+func (c *mockExtendedMetricsCollector) RecordSyncErrors(op, errType string)             {}
 func (c *mockExtendedMetricsCollector) RecordResolution(rule, group, decision string, dur time.Duration, success bool) {
 	c.resolutions = append(c.resolutions, resolutionMetric{
 		RuleName:  rule,
-		GroupName: group, 
+		GroupName: group,
 		Decision:  decision,
 		Duration:  dur,
 		Success:   success,
 	})
 }
-func (c *mockExtendedMetricsCollector) RecordRuleMatch(rule, group string) {}
-func (c *mockExtendedMetricsCollector) RecordFallbackUsage(group string) {}
+func (c *mockExtendedMetricsCollector) RecordRuleMatch(rule, group string)                {}
+func (c *mockExtendedMetricsCollector) RecordFallbackUsage(group string)                  {}
 func (c *mockExtendedMetricsCollector) RecordResolutionError(rule, group, errType string) {}
-func (c *mockExtendedMetricsCollector) RecordManualReview(reason string) {}
+func (c *mockExtendedMetricsCollector) RecordManualReview(reason string)                  {}

--- a/synckit/builder.go
+++ b/synckit/builder.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	"github.com/c0deZ3R0/go-sync-kit/logging"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ProjectionRunner is an interface that represents a projection runner.
@@ -15,7 +15,7 @@ import (
 type ProjectionRunner interface {
 	// ApplySince applies all events since the last saved offset
 	ApplySince(ctx context.Context) (applied int, last Version, err error)
-	
+
 	// ApplyBatch applies a specific batch of events directly
 	ApplyBatch(ctx context.Context, batch []EventWithVersion) error
 }
@@ -24,13 +24,13 @@ type ProjectionRunner interface {
 type ProjectionConfig struct {
 	// Runners are the projection runners to execute after successful sync
 	Runners []ProjectionRunner
-	
+
 	// RunOnSync enables automatic projection execution after sync
 	RunOnSync bool
-	
+
 	// MaxWorkers is the maximum number of concurrent projection workers
 	MaxWorkers int
-	
+
 	// Timeout is the timeout for projection operations
 	Timeout time.Duration
 }
@@ -43,12 +43,12 @@ type SyncManagerBuilder struct {
 	logger      *slog.Logger
 	pushOnlySet bool // Track if PushOnly was explicitly set
 	pullOnlySet bool // Track if PullOnly was explicitly set
-	
+
 	// Projection support
-	projectionRunners     []ProjectionRunner
-	runProjectionsOnSync  bool
-	projectionMaxWorkers  int
-	projectionTimeout     time.Duration
+	projectionRunners    []ProjectionRunner
+	runProjectionsOnSync bool
+	projectionMaxWorkers int
+	projectionTimeout    time.Duration
 }
 
 // NewSyncManagerBuilder creates a new builder with default options.
@@ -61,8 +61,8 @@ func NewSyncManagerBuilder() *SyncManagerBuilder {
 			EnableCompression: false,
 		},
 		logger:               logging.Default().Logger, // Use default logger
-		projectionMaxWorkers: 3,                         // Default to 3 concurrent projections
-		projectionTimeout:    30 * time.Second,          // Default timeout for projections
+		projectionMaxWorkers: 3,                        // Default to 3 concurrent projections
+		projectionTimeout:    30 * time.Second,         // Default timeout for projections
 	}
 }
 
@@ -218,12 +218,12 @@ func (b *SyncManagerBuilder) Build() (SyncManager, error) {
 
 	// Create projection configuration
 	projectionConfig := &ProjectionConfig{
-		Runners:     b.projectionRunners,
-		RunOnSync:   b.runProjectionsOnSync,
-		MaxWorkers:  b.projectionMaxWorkers,
-		Timeout:     b.projectionTimeout,
+		Runners:    b.projectionRunners,
+		RunOnSync:  b.runProjectionsOnSync,
+		MaxWorkers: b.projectionMaxWorkers,
+		Timeout:    b.projectionTimeout,
 	}
-	
+
 	// Create a new SyncManager instance with projection support
 	return NewSyncManager(b.store, b.transport, b.options, b.logger, projectionConfig), nil
 }
@@ -241,12 +241,12 @@ func (b *SyncManagerBuilder) Reset() *SyncManagerBuilder {
 	b.logger = logging.Default().Logger
 	b.pushOnlySet = false
 	b.pullOnlySet = false
-	
+
 	// Reset projection fields
 	b.projectionRunners = nil
 	b.runProjectionsOnSync = false
 	b.projectionMaxWorkers = 3
 	b.projectionTimeout = 30 * time.Second
-	
+
 	return b
 }

--- a/synckit/codec/codec.go
+++ b/synckit/codec/codec.go
@@ -53,7 +53,7 @@ func (r *Registry) Get(kind string) (Codec, bool) {
 func (r *Registry) Kinds() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	
+
 	kinds := make([]string, 0, len(r.codecs))
 	for kind := range r.codecs {
 		kinds = append(kinds, kind)

--- a/synckit/codec/codec_test.go
+++ b/synckit/codec/codec_test.go
@@ -43,13 +43,13 @@ func TestNewRegistry(t *testing.T) {
 func TestRegistry_Register(t *testing.T) {
 	registry := NewRegistry()
 	codec := &mockCodec{kind: "test"}
-	
+
 	registry.Register(codec)
-	
+
 	if len(registry.codecs) != 1 {
 		t.Fatalf("Expected 1 codec, got %d", len(registry.codecs))
 	}
-	
+
 	stored, ok := registry.codecs["test"]
 	if !ok {
 		t.Fatal("Codec not stored with correct key")
@@ -63,7 +63,7 @@ func TestRegistry_Get(t *testing.T) {
 	registry := NewRegistry()
 	codec := &mockCodec{kind: "test"}
 	registry.Register(codec)
-	
+
 	// Test existing codec
 	retrieved, ok := registry.Get("test")
 	if !ok {
@@ -72,7 +72,7 @@ func TestRegistry_Get(t *testing.T) {
 	if retrieved != codec {
 		t.Fatal("Retrieved codec is not the same instance")
 	}
-	
+
 	// Test non-existing codec
 	_, ok = registry.Get("nonexistent")
 	if ok {
@@ -82,32 +82,32 @@ func TestRegistry_Get(t *testing.T) {
 
 func TestRegistry_Kinds(t *testing.T) {
 	registry := NewRegistry()
-	
+
 	// Test empty registry
 	kinds := registry.Kinds()
 	if len(kinds) != 0 {
 		t.Fatal("Empty registry should return empty kinds slice")
 	}
-	
+
 	// Test with multiple codecs
 	codec1 := &mockCodec{kind: "type1"}
 	codec2 := &mockCodec{kind: "type2"}
 	codec3 := &mockCodec{kind: "type3"}
-	
+
 	registry.Register(codec1)
 	registry.Register(codec2)
 	registry.Register(codec3)
-	
+
 	kinds = registry.Kinds()
 	if len(kinds) != 3 {
 		t.Fatalf("Expected 3 kinds, got %d", len(kinds))
 	}
-	
+
 	// Sort for consistent comparison
 	sort.Strings(kinds)
 	expected := []string{"type1", "type2", "type3"}
 	sort.Strings(expected)
-	
+
 	if !reflect.DeepEqual(kinds, expected) {
 		t.Fatalf("Expected kinds %v, got %v", expected, kinds)
 	}
@@ -115,11 +115,11 @@ func TestRegistry_Kinds(t *testing.T) {
 
 func TestRegistry_ConcurrentAccess(t *testing.T) {
 	registry := NewRegistry()
-	
+
 	// Test concurrent registration and retrieval
 	var wg sync.WaitGroup
 	numGoroutines := 100
-	
+
 	// Concurrent registration
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
@@ -129,14 +129,14 @@ func TestRegistry_ConcurrentAccess(t *testing.T) {
 			registry.Register(codec)
 		}(i)
 	}
-	
+
 	wg.Wait()
-	
+
 	// Verify all codecs were registered
 	if len(registry.codecs) != numGoroutines {
 		t.Fatalf("Expected %d codecs, got %d", numGoroutines, len(registry.codecs))
 	}
-	
+
 	// Concurrent retrieval
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
@@ -149,7 +149,7 @@ func TestRegistry_ConcurrentAccess(t *testing.T) {
 			}
 		}(i)
 	}
-	
+
 	wg.Wait()
 }
 
@@ -161,24 +161,24 @@ func TestDefaultRegistry(t *testing.T) {
 		originalCodecs[k] = v
 	}
 	DefaultRegistry.mu.RUnlock()
-	
+
 	// Clean up after test
 	defer func() {
 		DefaultRegistry.mu.Lock()
 		DefaultRegistry.codecs = originalCodecs
 		DefaultRegistry.mu.Unlock()
 	}()
-	
+
 	// Clear default registry for test
 	DefaultRegistry.mu.Lock()
 	DefaultRegistry.codecs = make(map[string]Codec)
 	DefaultRegistry.mu.Unlock()
-	
+
 	codec := &mockCodec{kind: "default-test"}
-	
+
 	// Test global Register function
 	Register(codec)
-	
+
 	// Test global Get function
 	retrieved, ok := Get("default-test")
 	if !ok {
@@ -187,7 +187,7 @@ func TestDefaultRegistry(t *testing.T) {
 	if retrieved != codec {
 		t.Fatal("Retrieved codec is not the same instance")
 	}
-	
+
 	// Test non-existent
 	_, ok = Get("nonexistent")
 	if ok {
@@ -197,33 +197,33 @@ func TestDefaultRegistry(t *testing.T) {
 
 func TestCodec_Interface(t *testing.T) {
 	codec := &mockCodec{kind: "interface-test"}
-	
+
 	// Test Kind method
 	if codec.Kind() != "interface-test" {
 		t.Fatalf("Expected kind 'interface-test', got %s", codec.Kind())
 	}
-	
+
 	// Test Encode/Decode roundtrip
 	original := map[string]interface{}{
 		"test": "value",
 		"num":  42,
 	}
-	
+
 	encoded, err := codec.Encode(original)
 	if err != nil {
 		t.Fatalf("Encode failed: %v", err)
 	}
-	
+
 	decoded, err := codec.Decode(encoded)
 	if err != nil {
 		t.Fatalf("Decode failed: %v", err)
 	}
-	
+
 	decodedMap, ok := decoded.(map[string]interface{})
 	if !ok {
 		t.Fatal("Decoded value is not map[string]interface{}")
 	}
-	
+
 	if decodedMap["test"] != "value" || decodedMap["num"].(float64) != 42 {
 		t.Fatalf("Roundtrip failed, got %v", decodedMap)
 	}

--- a/synckit/composite.go
+++ b/synckit/composite.go
@@ -70,13 +70,13 @@ func (rg *RuleGroup) AddRule(rule Rule) *RuleGroup {
 	if !rg.enabled {
 		return rg // Skip adding rules if group is disabled
 	}
-	
+
 	// Namespace the rule name with the group name
 	namespacedRule := rule
 	if rule.Name != "" {
 		namespacedRule.Name = fmt.Sprintf("%s.%s", rg.Name, rule.Name)
 	}
-	
+
 	rg.rules = append(rg.rules, namespacedRule)
 	return rg
 }
@@ -86,13 +86,13 @@ func (rg *RuleGroup) AddSubGroup(subGroup *RuleGroup) *RuleGroup {
 	if !rg.enabled {
 		return rg // Skip adding subgroups if group is disabled
 	}
-	
+
 	// Store original name
 	originalSubGroupName := subGroup.Name
-	
+
 	// Namespace the subgroup name
 	subGroup.Name = fmt.Sprintf("%s.%s", rg.Name, subGroup.Name)
-	
+
 	// Update all rules in the subgroup to use the full namespace
 	for i := range subGroup.rules {
 		originalRuleName := subGroup.rules[i].Name
@@ -106,7 +106,7 @@ func (rg *RuleGroup) AddSubGroup(subGroup *RuleGroup) *RuleGroup {
 			subGroup.rules[i].Name = fmt.Sprintf("%s.%s", subGroup.Name, originalRuleName)
 		}
 	}
-	
+
 	rg.subGroups = append(rg.subGroups, subGroup)
 	return rg
 }
@@ -132,17 +132,17 @@ func (rg *RuleGroup) GetAllRules() []Rule {
 	if !rg.enabled {
 		return nil
 	}
-	
+
 	var allRules []Rule
-	
+
 	// Add rules from this group first
 	allRules = append(allRules, rg.rules...)
-	
+
 	// Then add rules from subgroups (depth-first)
 	for _, subGroup := range rg.subGroups {
 		allRules = append(allRules, subGroup.GetAllRules()...)
 	}
-	
+
 	return allRules
 }
 
@@ -152,7 +152,7 @@ func (rg *RuleGroup) ResolveInGroup(ctx context.Context, conflict Conflict) (Res
 	if !rg.enabled {
 		return ResolvedConflict{}, false, nil
 	}
-	
+
 	// Try rules in this group first
 	for _, rule := range rg.rules {
 		if rule.Matcher(conflict) {
@@ -163,7 +163,7 @@ func (rg *RuleGroup) ResolveInGroup(ctx context.Context, conflict Conflict) (Res
 			return resolved, true, nil
 		}
 	}
-	
+
 	// Try subgroups
 	for _, subGroup := range rg.subGroups {
 		if resolved, matched, err := subGroup.ResolveInGroup(ctx, conflict); err != nil {
@@ -172,7 +172,7 @@ func (rg *RuleGroup) ResolveInGroup(ctx context.Context, conflict Conflict) (Res
 			return resolved, true, nil
 		}
 	}
-	
+
 	// Try group-specific fallback if available
 	if rg.fallback != nil {
 		resolved, err := rg.fallback.Resolve(ctx, conflict)
@@ -181,34 +181,34 @@ func (rg *RuleGroup) ResolveInGroup(ctx context.Context, conflict Conflict) (Res
 		}
 		return resolved, true, nil
 	}
-	
+
 	return ResolvedConflict{}, false, nil
 }
 
 // GetStats returns statistics about the rule group structure.
 func (rg *RuleGroup) GetStats() RuleGroupStats {
 	stats := RuleGroupStats{
-		Name:         rg.Name,
-		Enabled:      rg.enabled,
-		RuleCount:    len(rg.rules),
+		Name:          rg.Name,
+		Enabled:       rg.enabled,
+		RuleCount:     len(rg.rules),
 		SubGroupCount: len(rg.subGroups),
-		TotalRules:   len(rg.GetAllRules()),
+		TotalRules:    len(rg.GetAllRules()),
 	}
-	
+
 	for _, subGroup := range rg.subGroups {
 		stats.SubGroups = append(stats.SubGroups, subGroup.GetStats())
 	}
-	
+
 	return stats
 }
 
 // RuleGroupStats provides statistical information about rule group structure.
 type RuleGroupStats struct {
-	Name          string          `json:"name"`
-	Enabled       bool            `json:"enabled"`
-	RuleCount     int             `json:"rule_count"`      // Direct rules in this group
-	SubGroupCount int             `json:"subgroup_count"`  // Number of direct subgroups
-	TotalRules    int             `json:"total_rules"`     // Total rules including subgroups
+	Name          string           `json:"name"`
+	Enabled       bool             `json:"enabled"`
+	RuleCount     int              `json:"rule_count"`     // Direct rules in this group
+	SubGroupCount int              `json:"subgroup_count"` // Number of direct subgroups
+	TotalRules    int              `json:"total_rules"`    // Total rules including subgroups
 	SubGroups     []RuleGroupStats `json:"subgroups,omitempty"`
 }
 
@@ -226,11 +226,11 @@ func NewCompositeResolver(fallback ConflictResolver, opts ...CompositeOption) *C
 		groups:   make([]*RuleGroup, 0),
 		fallback: fallback,
 	}
-	
+
 	for _, opt := range opts {
 		opt.apply(cr)
 	}
-	
+
 	return cr
 }
 
@@ -275,7 +275,7 @@ func (cr *CompositeResolver) Resolve(ctx context.Context, conflict Conflict) (Re
 			return resolved, nil
 		}
 	}
-	
+
 	// Fall back to global fallback
 	if cr.fallback != nil {
 		if cr.logger != nil {
@@ -283,7 +283,7 @@ func (cr *CompositeResolver) Resolve(ctx context.Context, conflict Conflict) (Re
 		}
 		return cr.fallback.Resolve(ctx, conflict)
 	}
-	
+
 	return ResolvedConflict{}, fmt.Errorf("no rule groups matched conflict and no fallback provided")
 }
 

--- a/synckit/config.go
+++ b/synckit/config.go
@@ -14,12 +14,12 @@ import (
 // ConfigLoader provides dynamic loading and validation of conflict resolution rules
 // from YAML or JSON configuration files with runtime update capabilities.
 type ConfigLoader struct {
-	mu              sync.RWMutex
-	currentConfig   *RuleConfig
-	validators      []ConfigValidator
-	watchers        []ConfigWatcher
-	transformers    []ConfigTransformer
-	logger          Logger
+	mu            sync.RWMutex
+	currentConfig *RuleConfig
+	validators    []ConfigValidator
+	watchers      []ConfigWatcher
+	transformers  []ConfigTransformer
+	logger        Logger
 }
 
 // RuleConfig represents the complete configuration structure for conflict resolution rules.
@@ -28,13 +28,13 @@ type RuleConfig struct {
 	Name        string                 `json:"name" yaml:"name"`
 	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	
+
 	// Global settings
 	Settings ConfigSettings `json:"settings,omitempty" yaml:"settings,omitempty"`
-	
+
 	// Rule groups
 	Groups []GroupConfig `json:"groups" yaml:"groups"`
-	
+
 	// Global rules (not in any group)
 	Rules []RuleConfigEntry `json:"rules,omitempty" yaml:"rules,omitempty"`
 }
@@ -50,7 +50,7 @@ type ConfigSettings struct {
 
 // TimeoutSettings contains timeout configurations.
 type TimeoutSettings struct {
-	ResolutionTimeoutMs int `json:"resolution_timeout_ms,omitempty" yaml:"resolution_timeout_ms,omitempty"`
+	ResolutionTimeoutMs   int `json:"resolution_timeout_ms,omitempty" yaml:"resolution_timeout_ms,omitempty"`
 	ManualReviewTimeoutMs int `json:"manual_review_timeout_ms,omitempty" yaml:"manual_review_timeout_ms,omitempty"`
 }
 
@@ -62,38 +62,38 @@ type LimitSettings struct {
 
 // GroupConfig represents a rule group configuration.
 type GroupConfig struct {
-	Name        string              `json:"name" yaml:"name"`
-	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
-	Enabled     *bool               `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Fallback    string              `json:"fallback,omitempty" yaml:"fallback,omitempty"`
-	Rules       []RuleConfigEntry   `json:"rules" yaml:"rules"`
-	SubGroups   []GroupConfig       `json:"subgroups,omitempty" yaml:"subgroups,omitempty"`
+	Name        string                 `json:"name" yaml:"name"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled     *bool                  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Fallback    string                 `json:"fallback,omitempty" yaml:"fallback,omitempty"`
+	Rules       []RuleConfigEntry      `json:"rules" yaml:"rules"`
+	SubGroups   []GroupConfig          `json:"subgroups,omitempty" yaml:"subgroups,omitempty"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // RuleConfigEntry represents a single rule configuration.
 type RuleConfigEntry struct {
-	Name        string                 `json:"name" yaml:"name"`
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Enabled     *bool                  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Priority    int                    `json:"priority,omitempty" yaml:"priority,omitempty"`
-	
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled     *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Priority    int    `json:"priority,omitempty" yaml:"priority,omitempty"`
+
 	// Matching conditions
 	Conditions MatchConditions `json:"conditions" yaml:"conditions"`
-	
+
 	// Resolution configuration
 	Resolution ResolutionConfig `json:"resolution" yaml:"resolution"`
-	
+
 	// Metadata for custom extensions
 	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 // MatchConditions defines when a rule should be applied.
 type MatchConditions struct {
-	EventTypes    []string          `json:"event_types,omitempty" yaml:"event_types,omitempty"`
-	AggregateIDs  []string          `json:"aggregate_ids,omitempty" yaml:"aggregate_ids,omitempty"`
-	Fields        []string          `json:"fields,omitempty" yaml:"fields,omitempty"`
-	CustomMatch   map[string]string `json:"custom_match,omitempty" yaml:"custom_match,omitempty"`
+	EventTypes   []string          `json:"event_types,omitempty" yaml:"event_types,omitempty"`
+	AggregateIDs []string          `json:"aggregate_ids,omitempty" yaml:"aggregate_ids,omitempty"`
+	Fields       []string          `json:"fields,omitempty" yaml:"fields,omitempty"`
+	CustomMatch  map[string]string `json:"custom_match,omitempty" yaml:"custom_match,omitempty"`
 }
 
 // ResolutionConfig defines how conflicts should be resolved.
@@ -128,11 +128,11 @@ func NewConfigLoader(opts ...ConfigLoaderOption) *ConfigLoader {
 		watchers:     make([]ConfigWatcher, 0),
 		transformers: make([]ConfigTransformer, 0),
 	}
-	
+
 	for _, opt := range opts {
 		opt.apply(cl)
 	}
-	
+
 	return cl
 }
 
@@ -179,22 +179,22 @@ func WithConfigLogger(logger Logger) ConfigLoaderOption {
 func (cl *ConfigLoader) LoadFromFile(filepath string) error {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
-	
+
 	if cl.logger != nil {
 		cl.logger.Debug("Loading configuration from file", "path", filepath)
 	}
-	
+
 	file, err := os.Open(filepath)
 	if err != nil {
 		return fmt.Errorf("failed to open config file %s: %w", filepath, err)
 	}
 	defer file.Close()
-	
+
 	data, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("failed to read config file %s: %w", filepath, err)
 	}
-	
+
 	return cl.loadFromBytes(data, detectFormat(filepath))
 }
 
@@ -202,13 +202,13 @@ func (cl *ConfigLoader) LoadFromFile(filepath string) error {
 func (cl *ConfigLoader) LoadFromBytes(data []byte, format string) error {
 	cl.mu.Lock()
 	defer cl.mu.Unlock()
-	
+
 	return cl.loadFromBytes(data, format)
 }
 
 func (cl *ConfigLoader) loadFromBytes(data []byte, format string) error {
 	var config RuleConfig
-	
+
 	switch strings.ToLower(format) {
 	case "yaml", "yml":
 		if err := yaml.Unmarshal(data, &config); err != nil {
@@ -221,7 +221,7 @@ func (cl *ConfigLoader) loadFromBytes(data []byte, format string) error {
 	default:
 		return fmt.Errorf("unsupported config format: %s", format)
 	}
-	
+
 	return cl.applyConfig(&config)
 }
 
@@ -238,7 +238,7 @@ func (cl *ConfigLoader) applyConfig(config *RuleConfig) error {
 		}
 		config = transformed
 	}
-	
+
 	// Validate configuration
 	for _, validator := range cl.validators {
 		if err := validator.Validate(config); err != nil {
@@ -248,10 +248,10 @@ func (cl *ConfigLoader) applyConfig(config *RuleConfig) error {
 			return fmt.Errorf("validator %s failed: %w", validator.Name(), err)
 		}
 	}
-	
+
 	oldConfig := cl.currentConfig
 	cl.currentConfig = config
-	
+
 	// Notify watchers
 	for _, watcher := range cl.watchers {
 		go func(w ConfigWatcher) {
@@ -265,11 +265,11 @@ func (cl *ConfigLoader) applyConfig(config *RuleConfig) error {
 			w.OnConfigChanged(oldConfig, config)
 		}(watcher)
 	}
-	
+
 	if cl.logger != nil {
 		cl.logger.Debug("Configuration applied successfully", "version", config.Version, "groups", len(config.Groups))
 	}
-	
+
 	return nil
 }
 
@@ -277,7 +277,7 @@ func (cl *ConfigLoader) applyConfig(config *RuleConfig) error {
 func (cl *ConfigLoader) GetCurrentConfig() *RuleConfig {
 	cl.mu.RLock()
 	defer cl.mu.RUnlock()
-	
+
 	return cl.currentConfig
 }
 
@@ -286,13 +286,13 @@ func (cl *ConfigLoader) BuildDynamicResolver() (*DynamicResolver, error) {
 	cl.mu.RLock()
 	config := cl.currentConfig
 	cl.mu.RUnlock()
-	
+
 	if config == nil {
 		return nil, fmt.Errorf("no configuration loaded")
 	}
-	
+
 	var options []Option
-	
+
 	// Set global fallback if specified
 	if config.Settings.DefaultFallback != "" {
 		fallback, err := cl.createResolverFromStrategy(config.Settings.DefaultFallback, nil)
@@ -301,7 +301,7 @@ func (cl *ConfigLoader) BuildDynamicResolver() (*DynamicResolver, error) {
 		}
 		options = append(options, WithFallback(fallback))
 	}
-	
+
 	// Add global rules
 	for _, ruleConfig := range config.Rules {
 		rule, err := cl.buildRule(ruleConfig)
@@ -310,7 +310,7 @@ func (cl *ConfigLoader) BuildDynamicResolver() (*DynamicResolver, error) {
 		}
 		options = append(options, WithRule(rule.Name, rule.Matcher, rule.Resolver))
 	}
-	
+
 	// Note: Group support would require CompositeResolver integration
 	// For now, we'll add group rules as individual rules with namespaced names
 	for _, groupConfig := range config.Groups {
@@ -324,24 +324,24 @@ func (cl *ConfigLoader) BuildDynamicResolver() (*DynamicResolver, error) {
 			options = append(options, WithRule(namespacedName, rule.Matcher, rule.Resolver))
 		}
 	}
-	
+
 	return NewDynamicResolver(options...)
 }
 
 // buildRuleGroup creates a RuleGroup from configuration.
 func (cl *ConfigLoader) buildRuleGroup(config GroupConfig) (*RuleGroup, error) {
 	opts := make([]RuleGroupOption, 0)
-	
+
 	if config.Description != "" {
 		opts = append(opts, WithDescription(config.Description))
 	}
-	
+
 	enabled := true
 	if config.Enabled != nil {
 		enabled = *config.Enabled
 	}
 	opts = append(opts, WithEnabled(enabled))
-	
+
 	if config.Fallback != "" {
 		fallback, err := cl.createResolverFromStrategy(config.Fallback, nil)
 		if err != nil {
@@ -349,9 +349,9 @@ func (cl *ConfigLoader) buildRuleGroup(config GroupConfig) (*RuleGroup, error) {
 		}
 		opts = append(opts, WithGroupFallback(fallback))
 	}
-	
+
 	group := NewRuleGroup(config.Name, opts...)
-	
+
 	// Add rules to group
 	for _, ruleConfig := range config.Rules {
 		rule, err := cl.buildRule(ruleConfig)
@@ -360,7 +360,7 @@ func (cl *ConfigLoader) buildRuleGroup(config GroupConfig) (*RuleGroup, error) {
 		}
 		group.AddRule(rule)
 	}
-	
+
 	// Add subgroups
 	for _, subGroupConfig := range config.SubGroups {
 		subGroup, err := cl.buildRuleGroup(subGroupConfig)
@@ -369,7 +369,7 @@ func (cl *ConfigLoader) buildRuleGroup(config GroupConfig) (*RuleGroup, error) {
 		}
 		group.AddSubGroup(subGroup)
 	}
-	
+
 	return group, nil
 }
 
@@ -380,48 +380,48 @@ func (cl *ConfigLoader) buildRule(config RuleConfigEntry) (Rule, error) {
 	if err != nil {
 		return Rule{}, fmt.Errorf("failed to build matcher: %w", err)
 	}
-	
+
 	// Build resolver
 	resolver, err := cl.createResolverFromStrategy(config.Resolution.Strategy, config.Resolution.Options)
 	if err != nil {
 		return Rule{}, fmt.Errorf("failed to create resolver: %w", err)
 	}
-	
+
 	rule := Rule{
 		Name:     config.Name,
 		Matcher:  matcher,
 		Resolver: resolver,
 	}
-	
+
 	return rule, nil
 }
 
 // buildMatcher creates a Spec from conditions.
 func (cl *ConfigLoader) buildMatcher(conditions MatchConditions) (Spec, error) {
 	var matchers []Spec
-	
+
 	// Event type matchers
 	for _, eventType := range conditions.EventTypes {
 		matchers = append(matchers, EventTypeIs(eventType))
 	}
-	
+
 	// Field matchers
 	for _, field := range conditions.Fields {
 		matchers = append(matchers, FieldChanged(field))
 	}
-	
+
 	// Aggregate ID matchers
 	for _, aggID := range conditions.AggregateIDs {
 		matchers = append(matchers, AggregateIDMatches(aggID))
 	}
-	
+
 	// Combine matchers
 	if len(matchers) == 0 {
 		return AlwaysMatch(), nil
 	} else if len(matchers) == 1 {
 		return matchers[0], nil
 	}
-	
+
 	// Use AND logic for multiple conditions
 	return AndMatcher(matchers...), nil
 }
@@ -468,11 +468,11 @@ func (v *BasicValidator) Validate(config *RuleConfig) error {
 	if config.Version == "" {
 		return fmt.Errorf("configuration version is required")
 	}
-	
+
 	if config.Name == "" {
 		return fmt.Errorf("configuration name is required")
 	}
-	
+
 	// Validate groups
 	groupNames := make(map[string]bool)
 	for _, group := range config.Groups {
@@ -483,17 +483,17 @@ func (v *BasicValidator) Validate(config *RuleConfig) error {
 			return fmt.Errorf("duplicate group name: %s", group.Name)
 		}
 		groupNames[group.Name] = true
-		
+
 		if err := v.validateRules(group.Rules, group.Name); err != nil {
 			return fmt.Errorf("invalid rules in group %s: %w", group.Name, err)
 		}
 	}
-	
+
 	// Validate global rules
 	if err := v.validateRules(config.Rules, "global"); err != nil {
 		return fmt.Errorf("invalid global rules: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -507,7 +507,7 @@ func (v *BasicValidator) validateRules(rules []RuleConfigEntry, context string) 
 			return fmt.Errorf("duplicate rule name: %s in %s", rule.Name, context)
 		}
 		ruleNames[rule.Name] = true
-		
+
 		if rule.Resolution.Strategy == "" {
 			return fmt.Errorf("resolution strategy is required for rule %s in %s", rule.Name, context)
 		}
@@ -534,11 +534,11 @@ func (w *LoggingWatcher) OnConfigChanged(oldConfig, newConfig *RuleConfig) {
 	if w.logger == nil {
 		return
 	}
-	
+
 	if oldConfig == nil {
 		w.logger.Debug("Initial configuration loaded", "version", newConfig.Version, "groups", len(newConfig.Groups))
 	} else {
-		w.logger.Debug("Configuration updated", 
+		w.logger.Debug("Configuration updated",
 			"old_version", oldConfig.Version,
 			"new_version", newConfig.Version,
 			"old_groups", len(oldConfig.Groups),

--- a/synckit/config_test.go
+++ b/synckit/config_test.go
@@ -114,9 +114,9 @@ func TestConfigLoader_BuildMatchersAndResolvers(t *testing.T) {
 
 	// Test the matcher function
 	conflict := Conflict{
-		EventType:      "UserCreated",
-		AggregateID:    "user-123",
-		ChangedFields:  []string{"email", "name"},
+		EventType:     "UserCreated",
+		AggregateID:   "user-123",
+		ChangedFields: []string{"email", "name"},
 	}
 
 	if !matcher(conflict) {

--- a/synckit/conflict_resolution_integration_test.go
+++ b/synckit/conflict_resolution_integration_test.go
@@ -138,18 +138,18 @@ type ConflictResolutionTestEvent struct {
 	metadata    map[string]interface{}
 }
 
-func (e *ConflictResolutionTestEvent) ID() string                         { return e.id }
-func (e *ConflictResolutionTestEvent) Type() string                       { return e.eventType }
-func (e *ConflictResolutionTestEvent) AggregateID() string                { return e.aggregateID }
-func (e *ConflictResolutionTestEvent) Data() interface{}                  { return e.data }
-func (e *ConflictResolutionTestEvent) Metadata() map[string]interface{}   { return e.metadata }
+func (e *ConflictResolutionTestEvent) ID() string                       { return e.id }
+func (e *ConflictResolutionTestEvent) Type() string                     { return e.eventType }
+func (e *ConflictResolutionTestEvent) AggregateID() string              { return e.aggregateID }
+func (e *ConflictResolutionTestEvent) Data() interface{}                { return e.data }
+func (e *ConflictResolutionTestEvent) Metadata() map[string]interface{} { return e.metadata }
 
 // ConflictResolutionTestVersion implements the Version interface for testing
 type ConflictResolutionTestVersion struct {
 	version string
 }
 
-func (v *ConflictResolutionTestVersion) String() string                    { return v.version }
+func (v *ConflictResolutionTestVersion) String() string { return v.version }
 func (v *ConflictResolutionTestVersion) Compare(other Version) int {
 	if other == nil {
 		return 1

--- a/synckit/manager_auto_sync_test.go
+++ b/synckit/manager_auto_sync_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 )
 
-
 func TestBatchProcessContextCancellation(t *testing.T) {
 	// Create events to process (reduced from 1000 to 100 to prevent timeouts)
 	localEvents := make([]EventWithVersion, 100)

--- a/synckit/manager_context_test.go
+++ b/synckit/manager_context_test.go
@@ -155,9 +155,9 @@ func (r *delayedResolver) Resolve(ctx context.Context, conflict Conflict) (Resol
 	select {
 	case <-time.After(r.delay):
 		return ResolvedConflict{
-			Decision:        "use_remote",
-			ResolvedEvents:  []EventWithVersion{conflict.Remote},
-			Reasons:         []string{"delayed resolver chose remote"},
+			Decision:       "use_remote",
+			ResolvedEvents: []EventWithVersion{conflict.Remote},
+			Reasons:        []string{"delayed resolver chose remote"},
 		}, nil
 	case <-ctx.Done():
 		return ResolvedConflict{}, ctx.Err()

--- a/synckit/manager_options.go
+++ b/synckit/manager_options.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	syncErrors "github.com/c0deZ3R0/go-sync-kit/errors"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ManagerOption is a functional option for configuring a SyncManager via NewManager.
@@ -54,11 +54,12 @@ func WithStore(s EventStore) ManagerOption {
 // WithSQLite constructs and injects a SQLite store.
 // Note: This function is provided as an example. In practice, you should
 // create your SQLite store separately and use WithStore() to avoid import cycles.
-// 
+//
 // Example:
-//   store, err := sqlite.NewWithDataSource("app.db")
-//   if err != nil { /* handle */ }
-//   mgr, err := synckit.NewManager(synckit.WithStore(store), ...)
+//
+//	store, err := sqlite.NewWithDataSource("app.db")
+//	if err != nil { /* handle */ }
+//	mgr, err := synckit.NewManager(synckit.WithStore(store), ...)
 func WithSQLite(path string) ManagerOption {
 	return func(b *SyncManagerBuilder) error {
 		return syncErrors.E(
@@ -76,8 +77,9 @@ func WithSQLite(path string) ManagerOption {
 // separately and use WithTransport() instead.
 //
 // Example:
-//   transport := httptransport.NewTransport("http://localhost:8080/sync", nil, nil, nil)
-//   mgr, err := synckit.NewManager(synckit.WithTransport(transport), ...)
+//
+//	transport := httptransport.NewTransport("http://localhost:8080/sync", nil, nil, nil)
+//	mgr, err := synckit.NewManager(synckit.WithTransport(transport), ...)
 func WithHTTPTransport(baseURL string) ManagerOption {
 	return func(b *SyncManagerBuilder) error {
 		return syncErrors.E(
@@ -222,8 +224,8 @@ func (n *nullTransport) Close() error {
 type nullVersion struct{}
 
 func (v *nullVersion) Compare(other Version) int { return 0 }
-func (v *nullVersion) String() string { return "0" }
-func (v *nullVersion) IsZero() bool { return true }
+func (v *nullVersion) String() string            { return "0" }
+func (v *nullVersion) IsZero() bool              { return true }
 
 // WithNullTransport configures a no-op transport for local-only scenarios.
 // Use this when you only need local event storage without remote synchronization.

--- a/synckit/memento.go
+++ b/synckit/memento.go
@@ -13,42 +13,42 @@ import (
 type ResolutionMemento struct {
 	// Unique identifier for this resolution
 	ID string `json:"id"`
-	
+
 	// Timestamp when the resolution occurred
 	Timestamp time.Time `json:"timestamp"`
-	
+
 	// Conflict information (serialization-friendly)
-	EventType     string            `json:"event_type"`
-	AggregateID   string            `json:"aggregate_id"`
-	ChangedFields []string          `json:"changed_fields,omitempty"`
-	Metadata      map[string]any    `json:"metadata,omitempty"`
-	
-	// Resolution result (serialization-friendly) 
+	EventType     string         `json:"event_type"`
+	AggregateID   string         `json:"aggregate_id"`
+	ChangedFields []string       `json:"changed_fields,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+
+	// Resolution result (serialization-friendly)
 	Decision string   `json:"decision"`
 	Reasons  []string `json:"reasons,omitempty"`
-	
+
 	// Resolution metadata
-	ResolverName string            `json:"resolver_name"`
-	RuleName     string            `json:"rule_name,omitempty"`
-	GroupName    string            `json:"group_name,omitempty"`
-	Context      map[string]any    `json:"context,omitempty"`
-	
+	ResolverName string         `json:"resolver_name"`
+	RuleName     string         `json:"rule_name,omitempty"`
+	GroupName    string         `json:"group_name,omitempty"`
+	Context      map[string]any `json:"context,omitempty"`
+
 	// Audit trail information
 	UserID    string `json:"user_id,omitempty"`
 	SessionID string `json:"session_id,omitempty"`
 	Origin    string `json:"origin,omitempty"`
-	
+
 	// Performance metrics
 	ResolutionDuration time.Duration `json:"resolution_duration"`
-	
+
 	// State before resolution (for rollback)
 	BeforeState *ConflictState `json:"before_state,omitempty"`
-	
+
 	// State after resolution
 	AfterState *ConflictState `json:"after_state,omitempty"`
-	
+
 	// For internal use - not serialized
-	OriginalConflict Conflict `json:"-"`
+	OriginalConflict Conflict         `json:"-"`
 	ResolvedConflict ResolvedConflict `json:"-"`
 }
 
@@ -56,14 +56,14 @@ type ResolutionMemento struct {
 // This struct is designed to be JSON serializable by storing only the data
 // payloads rather than the full Event interfaces.
 type ConflictState struct {
-	AggregateID    string         `json:"aggregate_id"`
-	EventType      string         `json:"event_type,omitempty"`
-	LocalVersion   string         `json:"local_version"`
-	RemoteVersion  string         `json:"remote_version"`
-	LocalData      any            `json:"local_data,omitempty"`
-	RemoteData     any            `json:"remote_data,omitempty"`
-	ResolvedData   any            `json:"resolved_data,omitempty"`
-	Metadata       map[string]any `json:"metadata,omitempty"`
+	AggregateID   string         `json:"aggregate_id"`
+	EventType     string         `json:"event_type,omitempty"`
+	LocalVersion  string         `json:"local_version"`
+	RemoteVersion string         `json:"remote_version"`
+	LocalData     any            `json:"local_data,omitempty"`
+	RemoteData    any            `json:"remote_data,omitempty"`
+	ResolvedData  any            `json:"resolved_data,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
 }
 
 // MementoCaretaker manages the storage and retrieval of resolution mementos.
@@ -71,30 +71,30 @@ type ConflictState struct {
 type MementoCaretaker interface {
 	// Save stores a resolution memento
 	Save(ctx context.Context, memento *ResolutionMemento) error
-	
+
 	// Get retrieves a specific memento by ID
 	Get(ctx context.Context, id string) (*ResolutionMemento, error)
-	
+
 	// List retrieves mementos based on criteria
 	List(ctx context.Context, criteria *MementoCriteria) ([]*ResolutionMemento, error)
-	
+
 	// Delete removes a memento (with appropriate authorization)
 	Delete(ctx context.Context, id string) error
-	
+
 	// GetAuditTrail returns the complete audit trail for an aggregate
 	GetAuditTrail(ctx context.Context, aggregateID string) ([]*ResolutionMemento, error)
 }
 
 // MementoCriteria defines search criteria for querying mementos.
 type MementoCriteria struct {
-	AggregateID   string     `json:"aggregate_id,omitempty"`
-	UserID        string     `json:"user_id,omitempty"`
-	ResolverName  string     `json:"resolver_name,omitempty"`
-	GroupName     string     `json:"group_name,omitempty"`
-	FromTime      *time.Time `json:"from_time,omitempty"`
-	ToTime        *time.Time `json:"to_time,omitempty"`
-	Limit         int        `json:"limit,omitempty"`
-	Offset        int        `json:"offset,omitempty"`
+	AggregateID  string     `json:"aggregate_id,omitempty"`
+	UserID       string     `json:"user_id,omitempty"`
+	ResolverName string     `json:"resolver_name,omitempty"`
+	GroupName    string     `json:"group_name,omitempty"`
+	FromTime     *time.Time `json:"from_time,omitempty"`
+	ToTime       *time.Time `json:"to_time,omitempty"`
+	Limit        int        `json:"limit,omitempty"`
+	Offset       int        `json:"offset,omitempty"`
 }
 
 // InMemoryMementoCaretaker provides an in-memory implementation of MementoCaretaker.
@@ -114,18 +114,18 @@ func (c *InMemoryMementoCaretaker) Save(ctx context.Context, memento *Resolution
 	if memento.ID == "" {
 		return fmt.Errorf("memento ID cannot be empty")
 	}
-	
+
 	// Deep copy to avoid external mutations
 	data, err := json.Marshal(memento)
 	if err != nil {
 		return fmt.Errorf("failed to serialize memento: %w", err)
 	}
-	
+
 	var copy ResolutionMemento
 	if err := json.Unmarshal(data, &copy); err != nil {
 		return fmt.Errorf("failed to deserialize memento: %w", err)
 	}
-	
+
 	c.mementos[memento.ID] = &copy
 	return nil
 }
@@ -135,24 +135,24 @@ func (c *InMemoryMementoCaretaker) Get(ctx context.Context, id string) (*Resolut
 	if !exists {
 		return nil, fmt.Errorf("memento with ID %s not found", id)
 	}
-	
+
 	// Return deep copy to prevent external mutations
 	data, err := json.Marshal(memento)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize memento: %w", err)
 	}
-	
+
 	var copy ResolutionMemento
 	if err := json.Unmarshal(data, &copy); err != nil {
 		return nil, fmt.Errorf("failed to deserialize memento: %w", err)
 	}
-	
+
 	return &copy, nil
 }
 
 func (c *InMemoryMementoCaretaker) List(ctx context.Context, criteria *MementoCriteria) ([]*ResolutionMemento, error) {
 	var results []*ResolutionMemento
-	
+
 	for _, memento := range c.mementos {
 		if c.matchesCriteria(memento, criteria) {
 			// Deep copy
@@ -162,7 +162,7 @@ func (c *InMemoryMementoCaretaker) List(ctx context.Context, criteria *MementoCr
 			results = append(results, &copy)
 		}
 	}
-	
+
 	// Apply limit and offset
 	if criteria != nil {
 		if criteria.Offset > 0 && criteria.Offset < len(results) {
@@ -172,7 +172,7 @@ func (c *InMemoryMementoCaretaker) List(ctx context.Context, criteria *MementoCr
 			results = results[:criteria.Limit]
 		}
 	}
-	
+
 	return results, nil
 }
 
@@ -180,7 +180,7 @@ func (c *InMemoryMementoCaretaker) Delete(ctx context.Context, id string) error 
 	if _, exists := c.mementos[id]; !exists {
 		return fmt.Errorf("memento with ID %s not found", id)
 	}
-	
+
 	delete(c.mementos, id)
 	return nil
 }
@@ -196,31 +196,31 @@ func (c *InMemoryMementoCaretaker) matchesCriteria(memento *ResolutionMemento, c
 	if criteria == nil {
 		return true
 	}
-	
+
 	if criteria.AggregateID != "" && memento.AggregateID != criteria.AggregateID {
 		return false
 	}
-	
+
 	if criteria.UserID != "" && memento.UserID != criteria.UserID {
 		return false
 	}
-	
+
 	if criteria.ResolverName != "" && memento.ResolverName != criteria.ResolverName {
 		return false
 	}
-	
+
 	if criteria.GroupName != "" && memento.GroupName != criteria.GroupName {
 		return false
 	}
-	
+
 	if criteria.FromTime != nil && memento.Timestamp.Before(*criteria.FromTime) {
 		return false
 	}
-	
+
 	if criteria.ToTime != nil && memento.Timestamp.After(*criteria.ToTime) {
 		return false
 	}
-	
+
 	return true
 }
 
@@ -229,7 +229,7 @@ type AuditableResolver struct {
 	wrapped   ConflictResolver
 	caretaker MementoCaretaker
 	logger    Logger
-	
+
 	// Context extractors for audit metadata
 	userIDExtractor    func(context.Context) string
 	sessionIDExtractor func(context.Context) string
@@ -242,11 +242,11 @@ func NewAuditableResolver(resolver ConflictResolver, caretaker MementoCaretaker,
 		wrapped:   resolver,
 		caretaker: caretaker,
 	}
-	
+
 	for _, opt := range opts {
 		opt.apply(ar)
 	}
-	
+
 	return ar
 }
 
@@ -292,7 +292,7 @@ func WithOriginExtractor(extractor func(context.Context) string) AuditableOption
 // Resolve implements ConflictResolver interface with audit trail creation.
 func (ar *AuditableResolver) Resolve(ctx context.Context, conflict Conflict) (ResolvedConflict, error) {
 	start := time.Now()
-	
+
 	// Create before state
 	beforeState := &ConflictState{
 		AggregateID:   conflict.AggregateID,
@@ -303,26 +303,26 @@ func (ar *AuditableResolver) Resolve(ctx context.Context, conflict Conflict) (Re
 		RemoteData:    conflict.Remote.Event.Data(),
 		Metadata:      conflict.Metadata,
 	}
-	
+
 	// Perform the actual resolution
 	resolved, err := ar.wrapped.Resolve(ctx, conflict)
 	duration := time.Since(start)
-	
+
 	// Create memento regardless of success/failure for audit purposes
 	memento := &ResolutionMemento{
 		ID:                 generateMementoID(),
-		Timestamp:         time.Now(),
-		EventType:         conflict.EventType,
-		AggregateID:       conflict.AggregateID,
-		ChangedFields:     conflict.ChangedFields,
-		Metadata:          conflict.Metadata,
-		OriginalConflict:  conflict,
-		ResolverName:      fmt.Sprintf("%T", ar.wrapped),
-		Context:           make(map[string]any),
+		Timestamp:          time.Now(),
+		EventType:          conflict.EventType,
+		AggregateID:        conflict.AggregateID,
+		ChangedFields:      conflict.ChangedFields,
+		Metadata:           conflict.Metadata,
+		OriginalConflict:   conflict,
+		ResolverName:       fmt.Sprintf("%T", ar.wrapped),
+		Context:            make(map[string]any),
 		ResolutionDuration: duration,
-		BeforeState:       beforeState,
+		BeforeState:        beforeState,
 	}
-	
+
 	// Extract audit metadata from context
 	if ar.userIDExtractor != nil {
 		memento.UserID = ar.userIDExtractor(ctx)
@@ -333,7 +333,7 @@ func (ar *AuditableResolver) Resolve(ctx context.Context, conflict Conflict) (Re
 	if ar.originExtractor != nil {
 		memento.Origin = ar.originExtractor(ctx)
 	}
-	
+
 	if err != nil {
 		// Record the error in context
 		memento.Context["error"] = err.Error()
@@ -344,7 +344,7 @@ func (ar *AuditableResolver) Resolve(ctx context.Context, conflict Conflict) (Re
 		memento.Decision = resolved.Decision
 		memento.Reasons = resolved.Reasons
 		memento.Context["success"] = true
-		
+
 		// Create after state
 		if len(resolved.ResolvedEvents) > 0 {
 			// Use the first resolved event as representative
@@ -358,14 +358,14 @@ func (ar *AuditableResolver) Resolve(ctx context.Context, conflict Conflict) (Re
 			}
 		}
 	}
-	
+
 	// Save memento (don't fail the resolution if audit save fails)
 	if saveErr := ar.caretaker.Save(ctx, memento); saveErr != nil && ar.logger != nil {
 		ar.logger.Error("Failed to save resolution memento", "error", saveErr, "memento_id", memento.ID)
 	} else if ar.logger != nil {
 		ar.logger.Debug("Saved resolution memento", "memento_id", memento.ID, "aggregate_id", conflict.AggregateID)
 	}
-	
+
 	return resolved, err
 }
 
@@ -391,13 +391,13 @@ func (rc *RollbackCapability) AnalyzeRollback(ctx context.Context, mementoID str
 	if err != nil {
 		return nil, fmt.Errorf("failed to get memento: %w", err)
 	}
-	
+
 	// Get subsequent resolutions for this aggregate
 	subsequent, err := rc.caretaker.GetAuditTrail(ctx, memento.AggregateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get audit trail: %w", err)
 	}
-	
+
 	// Find resolutions that occurred after this one
 	var affectedResolutions []*ResolutionMemento
 	for _, other := range subsequent {
@@ -405,14 +405,14 @@ func (rc *RollbackCapability) AnalyzeRollback(ctx context.Context, mementoID str
 			affectedResolutions = append(affectedResolutions, other)
 		}
 	}
-	
+
 	analysis := &RollbackAnalysis{
 		TargetMemento:        memento,
 		AffectedResolutions:  affectedResolutions,
 		RollbackComplexity:   calculateComplexity(affectedResolutions),
 		RequiresReprocessing: len(affectedResolutions) > 0,
 	}
-	
+
 	return analysis, nil
 }
 
@@ -420,9 +420,9 @@ func (rc *RollbackCapability) AnalyzeRollback(ctx context.Context, mementoID str
 type RollbackAnalysis struct {
 	TargetMemento        *ResolutionMemento   `json:"target_memento"`
 	AffectedResolutions  []*ResolutionMemento `json:"affected_resolutions"`
-	RollbackComplexity   string              `json:"rollback_complexity"`
-	RequiresReprocessing bool                `json:"requires_reprocessing"`
-	Warnings             []string            `json:"warnings,omitempty"`
+	RollbackComplexity   string               `json:"rollback_complexity"`
+	RequiresReprocessing bool                 `json:"requires_reprocessing"`
+	Warnings             []string             `json:"warnings,omitempty"`
 }
 
 func calculateComplexity(affectedResolutions []*ResolutionMemento) string {

--- a/synckit/multiuser_integration_test.go
+++ b/synckit/multiuser_integration_test.go
@@ -264,14 +264,14 @@ func testConcurrentResolverAccess(t *testing.T) {
 					EventType:   fmt.Sprintf("TestEvent-%d", j%3),
 					AggregateID: fmt.Sprintf("agg-%d-%d", goroutineID, j),
 					Metadata:    map[string]interface{}{"priority": "high", "goroutine": goroutineID},
-			Local: EventWithVersion{
-				Event:   &MultiUserTestEvent{id: fmt.Sprintf("local-%d-%d", goroutineID, j), typ: "TestEvent"},
-			Version: &testVersion{v: j},
-			},
-			Remote: EventWithVersion{
-				Event:   &MultiUserTestEvent{id: fmt.Sprintf("remote-%d-%d", goroutineID, j), typ: "TestEvent"},
-			Version: &testVersion{v: j + 1},
-			},
+					Local: EventWithVersion{
+						Event:   &MultiUserTestEvent{id: fmt.Sprintf("local-%d-%d", goroutineID, j), typ: "TestEvent"},
+						Version: &testVersion{v: j},
+					},
+					Remote: EventWithVersion{
+						Event:   &MultiUserTestEvent{id: fmt.Sprintf("remote-%d-%d", goroutineID, j), typ: "TestEvent"},
+						Version: &testVersion{v: j + 1},
+					},
 				}
 
 				// Each resolution should be deterministic and panic-free
@@ -576,7 +576,7 @@ func mustCreateResolver(t *testing.T, opts ...Option) *DynamicResolver {
 
 func mustCreateSyncManager(t *testing.T, store EventStore, transport Transport, resolver ConflictResolver) SyncManager {
 	t.Helper()
-	
+
 	builder := NewSyncManagerBuilder()
 	sm, err := builder.
 		WithStore(store).
@@ -585,7 +585,7 @@ func mustCreateSyncManager(t *testing.T, store EventStore, transport Transport, 
 		WithBatchSize(10).
 		WithLogger(slog.Default()).
 		Build()
-	
+
 	if err != nil {
 		t.Fatalf("Failed to create sync manager: %v", err)
 	}
@@ -628,8 +628,8 @@ type MultiUserTestEvent struct {
 	meta map[string]interface{}
 }
 
-func (e *MultiUserTestEvent) ID() string                        { return e.id }
-func (e *MultiUserTestEvent) Type() string                      { return e.typ }
-func (e *MultiUserTestEvent) AggregateID() string               { return e.agg }
-func (e *MultiUserTestEvent) Data() interface{}                 { return e.data }
+func (e *MultiUserTestEvent) ID() string                       { return e.id }
+func (e *MultiUserTestEvent) Type() string                     { return e.typ }
+func (e *MultiUserTestEvent) AggregateID() string              { return e.agg }
+func (e *MultiUserTestEvent) Data() interface{}                { return e.data }
 func (e *MultiUserTestEvent) Metadata() map[string]interface{} { return e.meta }

--- a/synckit/observer.go
+++ b/synckit/observer.go
@@ -11,17 +11,17 @@ import (
 // ObservableResolver wraps any ConflictResolver to provide detailed metrics and logging.
 // It implements the Observer pattern for monitoring conflict resolution performance.
 type ObservableResolver struct {
-	wrapped        ConflictResolver
-	metrics        MetricsCollector
-	logger         *slog.Logger
-	hooks          *ResolutionHooks
-	groupName      string // Optional: for group-level observability
+	wrapped   ConflictResolver
+	metrics   MetricsCollector
+	logger    *slog.Logger
+	hooks     *ResolutionHooks
+	groupName string // Optional: for group-level observability
 }
 
 // ExtendedMetricsCollector extends the basic MetricsCollector with detailed resolution metrics.
 type ExtendedMetricsCollector interface {
 	MetricsCollector // Embed existing interface
-	
+
 	// New methods for detailed conflict resolution metrics
 	RecordResolution(ruleName, groupName, decision string, duration time.Duration, success bool)
 	RecordRuleMatch(ruleName, groupName string)
@@ -32,11 +32,11 @@ type ExtendedMetricsCollector interface {
 
 // ResolutionHooks provides callbacks for observing conflict resolution events.
 type ResolutionHooks struct {
-	OnConflict      func(ctx context.Context, conflict *Conflict)
-	OnRuleMatched   func(ctx context.Context, conflict *Conflict, rule *Rule, group *RuleGroup)
-	OnResolution    func(ctx context.Context, result *ResolvedConflict, duration time.Duration)
-	OnFallback      func(ctx context.Context, conflict *Conflict, group *RuleGroup)
-	OnError         func(ctx context.Context, conflict *Conflict, err error)
+	OnConflict    func(ctx context.Context, conflict *Conflict)
+	OnRuleMatched func(ctx context.Context, conflict *Conflict, rule *Rule, group *RuleGroup)
+	OnResolution  func(ctx context.Context, result *ResolvedConflict, duration time.Duration)
+	OnFallback    func(ctx context.Context, conflict *Conflict, group *RuleGroup)
+	OnError       func(ctx context.Context, conflict *Conflict, err error)
 }
 
 // ObservableOption provides configuration for ObservableResolver.
@@ -83,35 +83,35 @@ func NewObservableResolver(resolver ConflictResolver, opts ...ObservableOption) 
 	or := &ObservableResolver{
 		wrapped: resolver,
 	}
-	
+
 	for _, opt := range opts {
 		opt.apply(or)
 	}
-	
+
 	return or
 }
 
 // Resolve implements the ConflictResolver interface with added observability.
 func (or *ObservableResolver) Resolve(ctx context.Context, conflict Conflict) (ResolvedConflict, error) {
 	start := time.Now()
-	
+
 	// Trigger OnConflict hook
 	if or.hooks != nil && or.hooks.OnConflict != nil {
 		or.hooks.OnConflict(ctx, &conflict)
 	}
-	
+
 	// Log the conflict
 	if or.logger != nil {
 		or.logger.Debug("Attempting to resolve conflict", "aggregate_id", conflict.AggregateID, "group", or.groupName)
 	}
-	
+
 	// Perform the actual resolution
 	resolved, err := or.wrapped.Resolve(ctx, conflict)
 	duration := time.Since(start)
-	
+
 	// Get resolution details
 	_, ruleName := getResolverDetails(or.wrapped)
-	
+
 	// Record metrics and call hooks
 	if err != nil {
 		if or.metrics != nil {
@@ -144,7 +144,7 @@ func (or *ObservableResolver) Resolve(ctx context.Context, conflict Conflict) (R
 			or.logger.Info("Conflict resolved successfully", "decision", resolved.Decision, "duration", duration)
 		}
 	}
-	
+
 	return resolved, err
 }
 
@@ -185,9 +185,9 @@ type ExtendedNoOpMetricsCollector struct {
 	NoOpMetricsCollector // Embed existing no-op collector
 }
 
-func (c *ExtendedNoOpMetricsCollector) RecordResolution(rule, group, decision string, dur time.Duration, success bool) {}
-func (c *ExtendedNoOpMetricsCollector) RecordRuleMatch(rule, group string)                 {}
-func (c *ExtendedNoOpMetricsCollector) RecordFallbackUsage(group string)                   {}
+func (c *ExtendedNoOpMetricsCollector) RecordResolution(rule, group, decision string, dur time.Duration, success bool) {
+}
+func (c *ExtendedNoOpMetricsCollector) RecordRuleMatch(rule, group string)                {}
+func (c *ExtendedNoOpMetricsCollector) RecordFallbackUsage(group string)                  {}
 func (c *ExtendedNoOpMetricsCollector) RecordResolutionError(rule, group, errType string) {}
-func (c *ExtendedNoOpMetricsCollector) RecordManualReview(reason string)                 {}
-
+func (c *ExtendedNoOpMetricsCollector) RecordManualReview(reason string)                  {}

--- a/synckit/realtime.go
+++ b/synckit/realtime.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -285,7 +286,7 @@ func (rsm *realtimeSyncManager) handleNotifications(ctx context.Context) {
 
 	// Add maximum timeout for connection attempts
 	maxTimeout := 5 * time.Minute
-	attempt := 0
+	var attempt int64 = 0
 
 	for {
 		// FIXED: Check stop channel under lock to avoid race
@@ -309,7 +310,7 @@ func (rsm *realtimeSyncManager) handleNotifications(ctx context.Context) {
 		err := notifier.Subscribe(ctx, func(notification Notification) error {
 			// Reset backoff on successful notification
 			backoff.Reset()
-			attempt = 0
+			atomic.StoreInt64(&attempt, 0)
 
 			// FIXED: Use thread-safe helper method
 			rsm.updateConnectionStatus(true, time.Now(), nil)
@@ -342,7 +343,7 @@ func (rsm *realtimeSyncManager) handleNotifications(ctx context.Context) {
 		if err != nil {
 			// FIXED: Use thread-safe helper methods
 			rsm.updateConnectionStatus(false, time.Time{}, err)
-			rsm.updateReconnectAttempts(attempt)
+			rsm.updateReconnectAttempts(int(atomic.LoadInt64(&attempt)))
 
 			// Start fallback polling if not disabled
 			if !rsm.realtimeOptions.DisablePolling && rsm.fallbackTicker == nil {
@@ -350,11 +351,12 @@ func (rsm *realtimeSyncManager) handleNotifications(ctx context.Context) {
 			}
 
 			// Wait before reconnecting
-			delay := backoff.NextDelay(attempt)
+			currentAttempt := int(atomic.LoadInt64(&attempt))
+			delay := backoff.NextDelay(currentAttempt)
 			if delay > maxTimeout {
 				delay = maxTimeout
 			}
-			attempt++
+			atomic.AddInt64(&attempt, 1)
 
 			// FIXED: Check stop channel under lock to avoid race
 			rsm.realtimeMu.RLock()

--- a/synckit/resolver.go
+++ b/synckit/resolver.go
@@ -30,10 +30,10 @@ type Validator interface {
 
 // resolverOptions holds construction-time options.
 type resolverOptions struct {
-	rules    []Rule
-	fallback ConflictResolver
-	logger   any
-	hooks    Hooks
+	rules     []Rule
+	fallback  ConflictResolver
+	logger    any
+	hooks     Hooks
 	validator Validator
 }
 
@@ -41,10 +41,13 @@ type resolverOptions struct {
 type Option interface{ apply(*resolverOptions) }
 
 type optionFn func(*resolverOptions)
+
 func (f optionFn) apply(o *resolverOptions) { f(o) }
 
 // WithFallback sets the required fallback ConflictResolver.
-func WithFallback(r ConflictResolver) Option { return optionFn(func(o *resolverOptions) { o.fallback = r }) }
+func WithFallback(r ConflictResolver) Option {
+	return optionFn(func(o *resolverOptions) { o.fallback = r })
+}
 
 // WithRule appends a rule with a custom matcher and resolver in insertion order.
 func WithRule(name string, matcher Spec, resolver ConflictResolver) Option {
@@ -86,7 +89,9 @@ var _ ConflictResolver = (*DynamicResolver)(nil)
 // - If provided, Validator must approve the configuration
 func NewDynamicResolver(opts ...Option) (*DynamicResolver, error) {
 	cfg := &resolverOptions{}
-	for _, opt := range opts { opt.apply(cfg) }
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
 
 	// Basic validation
 	if len(cfg.rules) == 0 && cfg.fallback == nil {
@@ -94,14 +99,16 @@ func NewDynamicResolver(opts ...Option) (*DynamicResolver, error) {
 	}
 	for i, r := range cfg.rules {
 		if r.Matcher == nil {
-			return nil, errors.New("rule has nil matcher at index "+itoa(i))
+			return nil, errors.New("rule has nil matcher at index " + itoa(i))
 		}
 		if r.Resolver == nil {
-			return nil, errors.New("rule has nil resolver at index "+itoa(i))
+			return nil, errors.New("rule has nil resolver at index " + itoa(i))
 		}
 	}
 	if cfg.validator != nil {
-		if err := cfg.validator.Validate(cfg); err != nil { return nil, err }
+		if err := cfg.validator.Validate(cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	return &DynamicResolver{
@@ -117,35 +124,54 @@ func NewDynamicResolver(opts ...Option) (*DynamicResolver, error) {
 func (d *DynamicResolver) Resolve(ctx context.Context, c Conflict) (ResolvedConflict, error) {
 	for _, r := range d.rules {
 		if r.Matcher != nil && r.Matcher(c) {
-			if d.hooks.OnRuleMatched != nil { d.hooks.OnRuleMatched(c, r) }
+			if d.hooks.OnRuleMatched != nil {
+				d.hooks.OnRuleMatched(c, r)
+			}
 			res, err := r.Resolver.Resolve(ctx, c)
 			if err != nil {
-			if d.hooks.OnError != nil { d.hooks.OnError(c, err) }
-			return ResolvedConflict{}, err
+				if d.hooks.OnError != nil {
+					d.hooks.OnError(c, err)
+				}
+				return ResolvedConflict{}, err
 			}
-			if d.hooks.OnResolved != nil { d.hooks.OnResolved(c, res) }
+			if d.hooks.OnResolved != nil {
+				d.hooks.OnResolved(c, res)
+			}
 			return res, nil
 		}
 	}
 	if d.fallback == nil {
-	if d.hooks.OnError != nil { d.hooks.OnError(c, errors.New("no rule matched and no fallback configured")) }
-	return ResolvedConflict{}, errors.New("no rule matched and no fallback configured")
+		if d.hooks.OnError != nil {
+			d.hooks.OnError(c, errors.New("no rule matched and no fallback configured"))
+		}
+		return ResolvedConflict{}, errors.New("no rule matched and no fallback configured")
 	}
-	if d.hooks.OnFallback != nil { d.hooks.OnFallback(c) }
+	if d.hooks.OnFallback != nil {
+		d.hooks.OnFallback(c)
+	}
 	res, err := d.fallback.Resolve(ctx, c)
 	if err != nil {
-		if d.hooks.OnError != nil { d.hooks.OnError(c, err) }
+		if d.hooks.OnError != nil {
+			d.hooks.OnError(c, err)
+		}
 		return ResolvedConflict{}, err
 	}
-	if d.hooks.OnResolved != nil { d.hooks.OnResolved(c, res) }
+	if d.hooks.OnResolved != nil {
+		d.hooks.OnResolved(c, res)
+	}
 	return res, nil
 }
 
 // itoa avoids importing strconv for a simple positive int to string conversion.
 func itoa(i int) string {
-	if i == 0 { return "0" }
+	if i == 0 {
+		return "0"
+	}
 	neg := false
-	if i < 0 { neg = true; i = -i }
+	if i < 0 {
+		neg = true
+		i = -i
+	}
 	buf := [20]byte{}
 	n := len(buf)
 	for i > 0 {
@@ -153,6 +179,9 @@ func itoa(i int) string {
 		buf[n] = byte('0' + i%10)
 		i /= 10
 	}
-	if neg { n--; buf[n] = '-' }
+	if neg {
+		n--
+		buf[n] = '-'
+	}
 	return string(buf[n:])
 }

--- a/synckit/resolver_benchmark_test.go
+++ b/synckit/resolver_benchmark_test.go
@@ -8,7 +8,7 @@ import (
 func BenchmarkDynamicResolver_Dispatch_FirstMatch(b *testing.B) {
 	match := func(Conflict) bool { return true }
 	nomatch := func(Conflict) bool { return false }
-	mr := &mockResolver{res: ResolvedConflict{Decision:"ok"}}
+	mr := &mockResolver{res: ResolvedConflict{Decision: "ok"}}
 	dr, _ := NewDynamicResolver(
 		WithRule("rule0", match, mr),
 		WithRule("rule1", nomatch, &mockResolver{}),
@@ -24,12 +24,16 @@ func BenchmarkDynamicResolver_Dispatch_FirstMatch(b *testing.B) {
 func BenchmarkDynamicResolver_Dispatch_MiddleMatch(b *testing.B) {
 	nomatch := func(Conflict) bool { return false }
 	match := func(Conflict) bool { return true }
-	mr := &mockResolver{res: ResolvedConflict{Decision:"ok"}}
+	mr := &mockResolver{res: ResolvedConflict{Decision: "ok"}}
 	// Position K=10 in a 20-rule chain
 	opts := make([]Option, 0, 22)
-	for i := 0; i < 10; i++ { opts = append(opts, WithRule("nm", nomatch, &mockResolver{})) }
+	for i := 0; i < 10; i++ {
+		opts = append(opts, WithRule("nm", nomatch, &mockResolver{}))
+	}
 	opts = append(opts, WithRule("m", match, mr))
-	for i := 0; i < 9; i++ { opts = append(opts, WithRule("nm2", nomatch, &mockResolver{})) }
+	for i := 0; i < 9; i++ {
+		opts = append(opts, WithRule("nm2", nomatch, &mockResolver{}))
+	}
 	opts = append(opts, WithFallback(&mockResolver{}))
 	dr, _ := NewDynamicResolver(opts...)
 	c := Conflict{}
@@ -41,7 +45,7 @@ func BenchmarkDynamicResolver_Dispatch_MiddleMatch(b *testing.B) {
 
 func BenchmarkDynamicResolver_Dispatch_Fallback(b *testing.B) {
 	nomatch := func(Conflict) bool { return false }
-	fb := &mockResolver{res: ResolvedConflict{Decision:"fb"}}
+	fb := &mockResolver{res: ResolvedConflict{Decision: "fb"}}
 	dr, _ := NewDynamicResolver(
 		WithRule("nm1", nomatch, &mockResolver{}),
 		WithRule("nm2", nomatch, &mockResolver{}),

--- a/synckit/resolver_fuzz_test.go
+++ b/synckit/resolver_fuzz_test.go
@@ -17,8 +17,8 @@ func FuzzDynamicResolver_Resolve(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, eventType, aggregateID, fieldsStr, metaKey, metaValue string, localVersion, remoteVersion int64) {
 		// Skip invalid UTF-8 strings to focus on logical fuzz testing
-		if !utf8.ValidString(eventType) || !utf8.ValidString(aggregateID) || 
-		   !utf8.ValidString(fieldsStr) || !utf8.ValidString(metaKey) || !utf8.ValidString(metaValue) {
+		if !utf8.ValidString(eventType) || !utf8.ValidString(aggregateID) ||
+			!utf8.ValidString(fieldsStr) || !utf8.ValidString(metaKey) || !utf8.ValidString(metaValue) {
 			return
 		}
 
@@ -59,20 +59,20 @@ func FuzzDynamicResolver_Resolve(f *testing.F) {
 			resolver *DynamicResolver
 		}{
 			{
-				name: "lww-only",
+				name:     "lww-only",
 				resolver: mustNewResolver(t, WithFallback(&LastWriteWinsResolver{})),
 			},
 			{
-				name: "additive-only",
+				name:     "additive-only",
 				resolver: mustNewResolver(t, WithFallback(&AdditiveMergeResolver{})),
 			},
 			{
-				name: "manual-only", 
+				name:     "manual-only",
 				resolver: mustNewResolver(t, WithFallback(&ManualReviewResolver{Reason: "fuzz"})),
 			},
 			{
 				name: "event-type-rule",
-				resolver: mustNewResolver(t, 
+				resolver: mustNewResolver(t,
 					WithEventTypeRule("match", eventType, &LastWriteWinsResolver{}),
 					WithFallback(&AdditiveMergeResolver{}),
 				),
@@ -126,8 +126,8 @@ func FuzzSpec_Combinators(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, eventType, aggregateID, fieldsStr, metaKey, metaValue string) {
 		// Skip invalid UTF-8
-		if !utf8.ValidString(eventType) || !utf8.ValidString(aggregateID) || 
-		   !utf8.ValidString(fieldsStr) || !utf8.ValidString(metaKey) || !utf8.ValidString(metaValue) {
+		if !utf8.ValidString(eventType) || !utf8.ValidString(aggregateID) ||
+			!utf8.ValidString(fieldsStr) || !utf8.ValidString(metaKey) || !utf8.ValidString(metaValue) {
 			return
 		}
 
@@ -164,7 +164,7 @@ func FuzzSpec_Combinators(f *testing.F) {
 			spec Spec
 		}{
 			{"event", eventSpec},
-			{"field", fieldSpec}, 
+			{"field", fieldSpec},
 			{"meta", metaSpec},
 			{"and", andSpec},
 			{"or", orSpec},
@@ -177,7 +177,7 @@ func FuzzSpec_Combinators(f *testing.F) {
 				// Should not panic and be deterministic
 				result1 := tc.spec(conflict)
 				result2 := tc.spec(conflict)
-				
+
 				if result1 != result2 {
 					t.Fatalf("Non-deterministic spec result for %s: %v vs %v", tc.name, result1, result2)
 				}
@@ -281,7 +281,7 @@ func (t fuzzTestVersion) Compare(other Version) int {
 	return 0
 }
 func (t fuzzTestVersion) String() string { return "" }
-func (t fuzzTestVersion) IsZero() bool  { return t.v == 0 }
+func (t fuzzTestVersion) IsZero() bool   { return t.v == 0 }
 
 // fuzzTestEvent is a simple Event implementation for fuzz testing
 type fuzzTestEvent struct {

--- a/synckit/resolver_test.go
+++ b/synckit/resolver_test.go
@@ -7,56 +7,80 @@ import (
 )
 
 // mockResolver is a simple test double implementing ConflictResolver.
-type mockResolver struct{
-	name string
-	res  ResolvedConflict
-	err  error
+type mockResolver struct {
+	name  string
+	res   ResolvedConflict
+	err   error
 	calls int
 }
 
 func (m *mockResolver) Resolve(ctx context.Context, c Conflict) (ResolvedConflict, error) {
 	m.calls++
-	if m.err != nil { return ResolvedConflict{}, m.err }
+	if m.err != nil {
+		return ResolvedConflict{}, m.err
+	}
 	return m.res, nil
 }
 
 func TestDynamicResolver_FirstMatchWins(t *testing.T) {
-	mr1 := &mockResolver{name:"r1", res: ResolvedConflict{Decision:"r1"}}
-	mr2 := &mockResolver{name:"r2", res: ResolvedConflict{Decision:"r2"}}
-	fb := &mockResolver{name:"fb", res: ResolvedConflict{Decision:"fb"}}
+	mr1 := &mockResolver{name: "r1", res: ResolvedConflict{Decision: "r1"}}
+	mr2 := &mockResolver{name: "r2", res: ResolvedConflict{Decision: "r2"}}
+	fb := &mockResolver{name: "fb", res: ResolvedConflict{Decision: "fb"}}
 
 	dr, err := NewDynamicResolver(
 		WithRule("not-matching", func(c Conflict) bool { return false }, mr1),
 		WithRule("match", func(c Conflict) bool { return true }, mr2),
 		WithFallback(fb),
 	)
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	res, err := dr.Resolve(context.Background(), Conflict{})
-	if err != nil { t.Fatalf("unexpected resolve error: %v", err) }
-	if res.Decision != "r2" { t.Fatalf("expected r2, got %s", res.Decision) }
-	if mr1.calls != 0 { t.Fatalf("expected r1 not called") }
-	if mr2.calls != 1 { t.Fatalf("expected r2 called once") }
-	if fb.calls != 0 { t.Fatalf("expected fallback not called") }
+	if err != nil {
+		t.Fatalf("unexpected resolve error: %v", err)
+	}
+	if res.Decision != "r2" {
+		t.Fatalf("expected r2, got %s", res.Decision)
+	}
+	if mr1.calls != 0 {
+		t.Fatalf("expected r1 not called")
+	}
+	if mr2.calls != 1 {
+		t.Fatalf("expected r2 called once")
+	}
+	if fb.calls != 0 {
+		t.Fatalf("expected fallback not called")
+	}
 }
 
 func TestDynamicResolver_Fallback(t *testing.T) {
-	fb := &mockResolver{name:"fb", res: ResolvedConflict{Decision:"fb"}}
+	fb := &mockResolver{name: "fb", res: ResolvedConflict{Decision: "fb"}}
 	dr, err := NewDynamicResolver(
 		WithRule("nope", func(c Conflict) bool { return false }, &mockResolver{}),
 		WithFallback(fb),
 	)
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	res, err := dr.Resolve(context.Background(), Conflict{})
-	if err != nil { t.Fatalf("unexpected resolve error: %v", err) }
-	if res.Decision != "fb" { t.Fatalf("expected fb, got %s", res.Decision) }
-	if fb.calls != 1 { t.Fatalf("expected fallback called once") }
+	if err != nil {
+		t.Fatalf("unexpected resolve error: %v", err)
+	}
+	if res.Decision != "fb" {
+		t.Fatalf("expected fb, got %s", res.Decision)
+	}
+	if fb.calls != 1 {
+		t.Fatalf("expected fallback called once")
+	}
 }
 
 func TestDynamicResolver_NoFallbackNoRules(t *testing.T) {
 	// Test constructor error when no rules AND no fallback
 	_, err := NewDynamicResolver()
-	if err == nil { t.Fatalf("expected constructor error with no rules and no fallback") }
+	if err == nil {
+		t.Fatalf("expected constructor error with no rules and no fallback")
+	}
 }
 
 func TestDynamicResolver_NoMatchingRuleNoFallbackError(t *testing.T) {
@@ -64,9 +88,13 @@ func TestDynamicResolver_NoMatchingRuleNoFallbackError(t *testing.T) {
 	dr, err := NewDynamicResolver(
 		WithRule("nope", func(c Conflict) bool { return false }, &mockResolver{}),
 	)
-	if err != nil { t.Fatalf("unexpected constructor error: %v", err) }
+	if err != nil {
+		t.Fatalf("unexpected constructor error: %v", err)
+	}
 	_, err = dr.Resolve(context.Background(), Conflict{})
-	if err == nil { t.Fatalf("expected resolve error when no rules match and no fallback") }
+	if err == nil {
+		t.Fatalf("expected resolve error when no rules match and no fallback")
+	}
 }
 
 func TestDynamicResolver_InvalidRuleErrors(t *testing.T) {
@@ -74,19 +102,23 @@ func TestDynamicResolver_InvalidRuleErrors(t *testing.T) {
 		WithRule("bad-matcher", nil, &mockResolver{}),
 		WithFallback(&mockResolver{}),
 	)
-	if err == nil { t.Fatalf("expected error for nil matcher") }
+	if err == nil {
+		t.Fatalf("expected error for nil matcher")
+	}
 
 	_, err = NewDynamicResolver(
 		WithRule("bad-resolver", func(c Conflict) bool { return true }, nil),
 		WithFallback(&mockResolver{}),
 	)
-	if err == nil { t.Fatalf("expected error for nil resolver") }
+	if err == nil {
+		t.Fatalf("expected error for nil resolver")
+	}
 }
 
 func TestDynamicResolver_Hooks(t *testing.T) {
 	var matched, resolved, fallbackCalled, errored bool
-	mr := &mockResolver{name:"ok", res: ResolvedConflict{Decision:"ok"}}
-	fb := &mockResolver{name:"fb", res: ResolvedConflict{Decision:"fb"}}
+	mr := &mockResolver{name: "ok", res: ResolvedConflict{Decision: "ok"}}
+	fb := &mockResolver{name: "fb", res: ResolvedConflict{Decision: "fb"}}
 
 	dr, err := NewDynamicResolver(
 		WithRule("match", func(c Conflict) bool { return true }, mr),
@@ -98,53 +130,83 @@ func TestDynamicResolver_Hooks(t *testing.T) {
 			OnError:       func(conflict Conflict, err error) { errored = true },
 		}),
 	)
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	_, err = dr.Resolve(context.Background(), Conflict{})
-	if err != nil { t.Fatalf("unexpected resolve error: %v", err) }
-	if !matched || !resolved { t.Fatalf("expected matched and resolved hooks to be called") }
-	if fallbackCalled { t.Fatalf("did not expect fallback hook") }
-	if errored { t.Fatalf("did not expect error hook") }
+	if err != nil {
+		t.Fatalf("unexpected resolve error: %v", err)
+	}
+	if !matched || !resolved {
+		t.Fatalf("expected matched and resolved hooks to be called")
+	}
+	if fallbackCalled {
+		t.Fatalf("did not expect fallback hook")
+	}
+	if errored {
+		t.Fatalf("did not expect error hook")
+	}
 }
 
 func TestDynamicResolver_ErrorPropagatesAndHookCalled(t *testing.T) {
-	mr := &mockResolver{name:"bad", err: errors.New("boom")}
+	mr := &mockResolver{name: "bad", err: errors.New("boom")}
 	var errored bool
 	dr, err := NewDynamicResolver(
 		WithRule("match", func(c Conflict) bool { return true }, mr),
-		WithHooks(Hooks{ OnError: func(conflict Conflict, err error) { errored = true } }),
+		WithHooks(Hooks{OnError: func(conflict Conflict, err error) { errored = true }}),
 	)
-	if err != nil { t.Fatalf("unexpected construct error: %v", err) }
+	if err != nil {
+		t.Fatalf("unexpected construct error: %v", err)
+	}
 	_, err = dr.Resolve(context.Background(), Conflict{})
-	if err == nil { t.Fatalf("expected resolve error") }
-	if !errored { t.Fatalf("expected error hook to be called") }
+	if err == nil {
+		t.Fatalf("expected resolve error")
+	}
+	if !errored {
+		t.Fatalf("expected error hook to be called")
+	}
 }
 
 func TestWithEventTypeRule_Helper(t *testing.T) {
-	mr := &mockResolver{name:"evt", res: ResolvedConflict{Decision:"evt"}}
-	fb := &mockResolver{name:"fb", res: ResolvedConflict{Decision:"fb"}}
+	mr := &mockResolver{name: "evt", res: ResolvedConflict{Decision: "evt"}}
+	fb := &mockResolver{name: "fb", res: ResolvedConflict{Decision: "fb"}}
 	dr, err := NewDynamicResolver(
 		WithEventTypeRule("evt", "UserUpdated", mr),
 		WithFallback(fb),
 	)
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
-	res, err := dr.Resolve(context.Background(), Conflict{EventType:"UserUpdated"})
-	if err != nil { t.Fatalf("unexpected resolve error: %v", err) }
-	if res.Decision != "evt" { t.Fatalf("expected evt, got %s", res.Decision) }
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	res, err := dr.Resolve(context.Background(), Conflict{EventType: "UserUpdated"})
+	if err != nil {
+		t.Fatalf("unexpected resolve error: %v", err)
+	}
+	if res.Decision != "evt" {
+		t.Fatalf("expected evt, got %s", res.Decision)
+	}
 }
 
 func TestDynamicResolver_OverlappingRules_FirstWins(t *testing.T) {
-	mr1 := &mockResolver{name:"r1", res: ResolvedConflict{Decision:"r1"}}
-	mr2 := &mockResolver{name:"r2", res: ResolvedConflict{Decision:"r2"}}
+	mr1 := &mockResolver{name: "r1", res: ResolvedConflict{Decision: "r1"}}
+	mr2 := &mockResolver{name: "r2", res: ResolvedConflict{Decision: "r2"}}
 	// Both rules match any conflict
 	dr, err := NewDynamicResolver(
 		WithRule("rule1", func(c Conflict) bool { return true }, mr1),
 		WithRule("rule2", func(c Conflict) bool { return true }, mr2),
 	)
-	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	res, err := dr.Resolve(context.Background(), Conflict{})
-	if err != nil { t.Fatalf("unexpected resolve error: %v", err) }
-	if res.Decision != "r1" { t.Fatalf("expected first rule (r1) to win, got %s", res.Decision) }
-	if mr1.calls != 1 || mr2.calls != 0 { t.Fatalf("expected r1 called once, r2 not called") }
+	if err != nil {
+		t.Fatalf("unexpected resolve error: %v", err)
+	}
+	if res.Decision != "r1" {
+		t.Fatalf("expected first rule (r1) to win, got %s", res.Decision)
+	}
+	if mr1.calls != 1 || mr2.calls != 0 {
+		t.Fatalf("expected r1 called once, r2 not called")
+	}
 }
 
 // testValidator errors if any rule has name "bad"; used to verify validator hook.
@@ -152,7 +214,9 @@ type testValidator struct{}
 
 func (testValidator) Validate(o *resolverOptions) error {
 	for _, r := range o.rules {
-		if r.Name == "bad" { return errors.New("bad rule not allowed") }
+		if r.Name == "bad" {
+			return errors.New("bad rule not allowed")
+		}
 	}
 	return nil
 }
@@ -162,24 +226,30 @@ func TestDynamicResolver_ValidatorCalled(t *testing.T) {
 		WithRule("ok", func(Conflict) bool { return true }, &mockResolver{}),
 		WithValidator(testValidator{}),
 	)
-	if err != nil { t.Fatalf("did not expect error for ok rule: %v", err) }
+	if err != nil {
+		t.Fatalf("did not expect error for ok rule: %v", err)
+	}
 
 	_, err = NewDynamicResolver(
 		WithRule("bad", func(Conflict) bool { return true }, &mockResolver{}),
 		WithValidator(testValidator{}),
 	)
-	if err == nil { t.Fatalf("expected validator error for bad rule") }
+	if err == nil {
+		t.Fatalf("expected validator error for bad rule")
+	}
 }
 
 func TestDynamicResolver_DeterministicOrder(t *testing.T) {
-	mr1 := &mockResolver{name:"r1", res: ResolvedConflict{Decision:"r1"}}
-	mr2 := &mockResolver{name:"r2", res: ResolvedConflict{Decision:"r2"}}
+	mr1 := &mockResolver{name: "r1", res: ResolvedConflict{Decision: "r1"}}
+	mr2 := &mockResolver{name: "r2", res: ResolvedConflict{Decision: "r2"}}
 	build := func() *DynamicResolver {
 		d, err := NewDynamicResolver(
 			WithRule("a", func(Conflict) bool { return true }, mr1),
 			WithRule("b", func(Conflict) bool { return true }, mr2),
 		)
-		if err != nil { t.Fatalf("construct: %v", err) }
+		if err != nil {
+			t.Fatalf("construct: %v", err)
+		}
 		return d
 	}
 	// Run multiple times to ensure stable selection
@@ -187,7 +257,11 @@ func TestDynamicResolver_DeterministicOrder(t *testing.T) {
 		mr1.calls, mr2.calls = 0, 0
 		dr := build()
 		res, err := dr.Resolve(context.Background(), Conflict{})
-		if err != nil { t.Fatalf("resolve: %v", err) }
-		if res.Decision != "r1" { t.Fatalf("iteration %d: expected r1, got %s", i, res.Decision) }
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if res.Decision != "r1" {
+			t.Fatalf("iteration %d: expected r1, got %s", i, res.Decision)
+		}
 	}
 }

--- a/synckit/resolvers.go
+++ b/synckit/resolvers.go
@@ -31,7 +31,7 @@ func (r *LastWriteWinsResolver) Resolve(ctx context.Context, c Conflict) (Resolv
 	case 1:
 		return ResolvedConflict{ResolvedEvents: []EventWithVersion{c.Local}, Decision: "keep_local", Reasons: []string{"local newer"}}, nil
 	default:
-	return ResolvedConflict{ResolvedEvents: []EventWithVersion{c.Remote}, Decision: "keep_remote", Reasons: []string{"equal versions, prefer remote"}}, nil
+		return ResolvedConflict{ResolvedEvents: []EventWithVersion{c.Remote}, Decision: "keep_remote", Reasons: []string{"equal versions, prefer remote"}}, nil
 	}
 }
 
@@ -72,6 +72,8 @@ type ManualReviewResolver struct{ Reason string }
 
 func (r *ManualReviewResolver) Resolve(ctx context.Context, c Conflict) (ResolvedConflict, error) {
 	reasons := []string{"manual review required"}
-	if r.Reason != "" { reasons = append(reasons, r.Reason) }
+	if r.Reason != "" {
+		reasons = append(reasons, r.Reason)
+	}
 	return ResolvedConflict{Decision: "manual_review", Reasons: reasons}, nil
 }

--- a/synckit/resolvers_enhanced_test.go
+++ b/synckit/resolvers_enhanced_test.go
@@ -15,12 +15,12 @@ func TestResolvers_EnhancedEdgeCases(t *testing.T) {
 		t.Run("BoundaryConditions", testLastWriteWinsBoundaryConditions)
 		t.Run("ErrorConditions", testLastWriteWinsErrorConditions)
 	})
-	
+
 	t.Run("AdditiveMergeResolver", func(t *testing.T) {
 		t.Run("EdgeCases", testAdditiveMergeEdgeCases)
 		t.Run("BoundaryConditions", testAdditiveMergeBoundaryConditions)
 	})
-	
+
 	t.Run("ManualReviewResolver", func(t *testing.T) {
 		t.Run("EdgeCases", testManualReviewEdgeCases)
 		t.Run("ReasonHandling", testManualReviewReasonHandling)
@@ -32,37 +32,37 @@ func testLastWriteWinsEdgeCases(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name      string
-		conflict  Conflict
-		wantDecision string
+		name           string
+		conflict       Conflict
+		wantDecision   string
 		wantEventCount int
-		wantError bool
+		wantError      bool
 	}{
 		{
 			name: "identical_versions_prefer_remote",
 			conflict: Conflict{
-			Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 5}},
-			Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 5}},
+				Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 5}},
+				Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 5}},
 			},
-			wantDecision: "keep_remote",
+			wantDecision:   "keep_remote",
 			wantEventCount: 1,
 		},
 		{
 			name: "zero_versions_both",
 			conflict: Conflict{
-			Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 0}},
-			Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 0}},
+				Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 0}},
+				Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 0}},
 			},
-			wantDecision: "keep_remote",
+			wantDecision:   "keep_remote",
 			wantEventCount: 1,
 		},
 		{
 			name: "very_large_version_numbers",
 			conflict: Conflict{
-			Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 999999999}},
-			Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 1000000000}},
+				Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 999999999}},
+				Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 1000000000}},
 			},
-			wantDecision: "keep_remote",
+			wantDecision:   "keep_remote",
 			wantEventCount: 1,
 		},
 		{
@@ -71,7 +71,7 @@ func testLastWriteWinsEdgeCases(t *testing.T) {
 				Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: -1}},
 				Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 1}},
 			},
-			wantDecision: "keep_remote",
+			wantDecision:   "keep_remote",
 			wantEventCount: 1,
 		},
 		{
@@ -80,7 +80,7 @@ func testLastWriteWinsEdgeCases(t *testing.T) {
 				Local:  EventWithVersion{Event: &testEvent{id: ""}, Version: &testVersion{v: 1}},
 				Remote: EventWithVersion{Event: &testEvent{id: ""}, Version: &testVersion{v: 2}},
 			},
-			wantDecision: "keep_remote",
+			wantDecision:   "keep_remote",
 			wantEventCount: 1,
 		},
 	}
@@ -88,7 +88,7 @@ func testLastWriteWinsEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := resolver.Resolve(ctx, tt.conflict)
-			
+
 			if tt.wantError && err == nil {
 				t.Errorf("Expected error but got none")
 				return
@@ -97,7 +97,7 @@ func testLastWriteWinsEdgeCases(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 				return
 			}
-			
+
 			if result.Decision != tt.wantDecision {
 				t.Errorf("Decision: got %s, want %s", result.Decision, tt.wantDecision)
 			}
@@ -115,12 +115,12 @@ func testLastWriteWinsBoundaryConditions(t *testing.T) {
 	// Test context cancellation
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
-	
+
 	conflict := Conflict{
 		Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 1}},
 		Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 2}},
 	}
-	
+
 	// Should still work even with cancelled context (no async operations)
 	result, err := resolver.Resolve(cancelCtx, conflict)
 	if err != nil {
@@ -134,7 +134,7 @@ func testLastWriteWinsBoundaryConditions(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 1*time.Millisecond)
 	defer timeoutCancel()
 	time.Sleep(2 * time.Millisecond) // Ensure timeout
-	
+
 	result, err = resolver.Resolve(timeoutCtx, conflict)
 	if err != nil {
 		t.Errorf("Unexpected error with timeout context: %v", err)
@@ -143,13 +143,13 @@ func testLastWriteWinsBoundaryConditions(t *testing.T) {
 
 func testLastWriteWinsErrorConditions(t *testing.T) {
 	resolver := &LastWriteWinsResolver{}
-	
+
 	// Test with invalid version comparison
 	invalidVersionConflict := Conflict{
 		Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &invalidVersion{}},
 		Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 2}},
 	}
-	
+
 	result, err := resolver.Resolve(context.Background(), invalidVersionConflict)
 	// Should handle gracefully - invalid version should return 0 from Compare
 	if err != nil {
@@ -207,7 +207,7 @@ func testAdditiveMergeEdgeCases(t *testing.T) {
 				},
 				Remote: EventWithVersion{
 					Event: &testEvent{
-						id:   "large-remote", 
+						id:   "large-remote",
 						data: strings.Repeat("y", 10000),
 					},
 					Version: &testVersion{v: 2},
@@ -233,15 +233,15 @@ func testAdditiveMergeEdgeCases(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 				return
 			}
-			
+
 			if len(result.ResolvedEvents) != tt.wantEventCount {
 				t.Errorf("Event count: got %d, want %d", len(result.ResolvedEvents), tt.wantEventCount)
 			}
-			
+
 			if result.Decision != "merge" && tt.wantEventCount > 0 {
 				t.Errorf("Expected merge decision for non-empty result, got %s", result.Decision)
 			}
-			
+
 			// Verify consistent ordering (local first, then remote)
 			if tt.checkOrder && len(result.ResolvedEvents) == 2 {
 				if result.ResolvedEvents[0].Event.ID() != "large-local" {
@@ -257,16 +257,16 @@ func testAdditiveMergeEdgeCases(t *testing.T) {
 
 func testAdditiveMergeBoundaryConditions(t *testing.T) {
 	resolver := &AdditiveMergeResolver{}
-	
+
 	// Test with many concurrent resolves (checking for race conditions)
 	const numResolves = 100
 	results := make(chan ResolvedConflict, numResolves)
-	
+
 	conflict := Conflict{
 		Local:  EventWithVersion{Event: &testEvent{id: "local"}, Version: &testVersion{v: 1}},
 		Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 2}},
 	}
-	
+
 	for i := 0; i < numResolves; i++ {
 		go func() {
 			result, err := resolver.Resolve(context.Background(), conflict)
@@ -277,7 +277,7 @@ func testAdditiveMergeBoundaryConditions(t *testing.T) {
 			results <- result
 		}()
 	}
-	
+
 	// Collect all results and verify consistency
 	for i := 0; i < numResolves; i++ {
 		result := <-results
@@ -292,10 +292,10 @@ func testAdditiveMergeBoundaryConditions(t *testing.T) {
 
 func testManualReviewEdgeCases(t *testing.T) {
 	tests := []struct {
-		name         string
-		reason       string
-		wantReasons  []string
-		checkReason  string
+		name        string
+		reason      string
+		wantReasons []string
+		checkReason string
 	}{
 		{
 			name:        "empty_reason",
@@ -325,30 +325,30 @@ func testManualReviewEdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver := &ManualReviewResolver{Reason: tt.reason}
-			
+
 			conflict := Conflict{
 				Local:  EventWithVersion{Event: &testEvent{id: "local"}},
 				Remote: EventWithVersion{Event: &testEvent{id: "remote"}},
 			}
-			
+
 			result, err := resolver.Resolve(context.Background(), conflict)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				return
 			}
-			
+
 			if result.Decision != "manual_review" {
 				t.Errorf("Expected manual_review, got %s", result.Decision)
 			}
-			
+
 			if len(result.ResolvedEvents) != 0 {
 				t.Errorf("Expected no resolved events, got %d", len(result.ResolvedEvents))
 			}
-			
+
 			if len(result.Reasons) != len(tt.wantReasons) {
 				t.Errorf("Reason count: got %d, want %d", len(result.Reasons), len(tt.wantReasons))
 			}
-			
+
 			// Check specific reason if provided
 			if tt.checkReason != "" {
 				found := false
@@ -368,13 +368,13 @@ func testManualReviewEdgeCases(t *testing.T) {
 
 func testManualReviewReasonHandling(t *testing.T) {
 	resolver := &ManualReviewResolver{Reason: "test reason"}
-	
+
 	// Test multiple sequential resolves maintain consistent reasons
 	conflict := Conflict{
 		Local:  EventWithVersion{Event: &testEvent{id: "local"}},
 		Remote: EventWithVersion{Event: &testEvent{id: "remote"}},
 	}
-	
+
 	const numResolves = 10
 	for i := 0; i < numResolves; i++ {
 		result, err := resolver.Resolve(context.Background(), conflict)
@@ -382,15 +382,15 @@ func testManualReviewReasonHandling(t *testing.T) {
 			t.Errorf("Resolve %d failed: %v", i, err)
 			continue
 		}
-		
+
 		expectedReasons := []string{"manual review required", "test reason"}
 		if len(result.Reasons) != len(expectedReasons) {
 			t.Errorf("Resolve %d: got %d reasons, want %d", i, len(result.Reasons), len(expectedReasons))
 		}
-		
+
 		for j, expected := range expectedReasons {
 			if j >= len(result.Reasons) || result.Reasons[j] != expected {
-				t.Errorf("Resolve %d: reason %d got %q, want %q", i, j, 
+				t.Errorf("Resolve %d: reason %d got %q, want %q", i, j,
 					safeGetReason(result.Reasons, j), expected)
 			}
 		}
@@ -408,10 +408,10 @@ func TestSpec_EnhancedEdgeCases(t *testing.T) {
 
 func testEventTypeIsEdgeCases(t *testing.T) {
 	tests := []struct {
-		name        string
-		matchType   string
-		conflict    Conflict
-		wantMatch   bool
+		name      string
+		matchType string
+		conflict  Conflict
+		wantMatch bool
 	}{
 		{
 			name:      "empty_match_type",
@@ -456,7 +456,7 @@ func testEventTypeIsEdgeCases(t *testing.T) {
 			spec := EventTypeIs(tt.matchType)
 			result := spec(tt.conflict)
 			if result != tt.wantMatch {
-				t.Errorf("EventTypeIs(%q) on %q: got %v, want %v", 
+				t.Errorf("EventTypeIs(%q) on %q: got %v, want %v",
 					tt.matchType, tt.conflict.EventType, result, tt.wantMatch)
 			}
 		})
@@ -465,10 +465,10 @@ func testEventTypeIsEdgeCases(t *testing.T) {
 
 func testAnyFieldInEdgeCases(t *testing.T) {
 	tests := []struct {
-		name        string
-		fields      []string
-		conflict    Conflict
-		wantMatch   bool
+		name      string
+		fields    []string
+		conflict  Conflict
+		wantMatch bool
 	}{
 		{
 			name:      "no_fields_to_match",
@@ -513,7 +513,7 @@ func testAnyFieldInEdgeCases(t *testing.T) {
 			wantMatch: true,
 		},
 		{
-			name: "large_field_list",
+			name:      "large_field_list",
 			fields:    generateFieldList(1000, "match_"),
 			conflict:  Conflict{ChangedFields: []string{"match_0", "other"}}, // match_0 exists in generated list
 			wantMatch: true,
@@ -525,7 +525,7 @@ func testAnyFieldInEdgeCases(t *testing.T) {
 			spec := AnyFieldIn(tt.fields...)
 			result := spec(tt.conflict)
 			if result != tt.wantMatch {
-				t.Errorf("AnyFieldIn(%v) on %v: got %v, want %v", 
+				t.Errorf("AnyFieldIn(%v) on %v: got %v, want %v",
 					tt.fields, tt.conflict.ChangedFields, result, tt.wantMatch)
 			}
 		})
@@ -628,7 +628,7 @@ func testCombinatorsEdgeCases(t *testing.T) {
 	// Create base specs for testing
 	alwaysTrue := func(Conflict) bool { return true }
 	alwaysFalse := func(Conflict) bool { return false }
-	
+
 	conflict := Conflict{EventType: "TestEvent"}
 
 	t.Run("nil_specs", func(t *testing.T) {
@@ -637,30 +637,30 @@ func testCombinatorsEdgeCases(t *testing.T) {
 		if andNilNil(conflict) != false {
 			t.Errorf("And(nil, nil) should return false")
 		}
-		
+
 		andTrueNil := And(alwaysTrue, nil)
 		if andTrueNil(conflict) != false {
 			t.Errorf("And(true, nil) should return false")
 		}
-		
+
 		// Or with nil specs
 		orNilNil := Or(nil, nil)
 		if orNilNil(conflict) != false {
 			t.Errorf("Or(nil, nil) should return false")
 		}
-		
+
 		orTrueNil := Or(alwaysTrue, nil)
 		if orTrueNil(conflict) != true {
 			t.Errorf("Or(true, nil) should return true")
 		}
-		
+
 		// Not with nil spec
 		notNil := Not(nil)
 		if notNil(conflict) != true {
 			t.Errorf("Not(nil) should return true")
 		}
 	})
-	
+
 	t.Run("complex_nesting", func(t *testing.T) {
 		// Create deeply nested combinator
 		eventTypeSpec := EventTypeIs("TestEvent")
@@ -668,7 +668,7 @@ func testCombinatorsEdgeCases(t *testing.T) {
 		orSpec := Or(eventTypeSpec, notEventType)
 		andSpec := And(orSpec, alwaysTrue)
 		finalSpec := Not(And(andSpec, alwaysFalse))
-		
+
 		// This should always be true due to the logic
 		if !finalSpec(conflict) {
 			t.Errorf("Complex nested spec should return true")
@@ -679,13 +679,13 @@ func testCombinatorsEdgeCases(t *testing.T) {
 		panicSpec := func(Conflict) bool {
 			panic("should not be called")
 		}
-		
+
 		// And should short-circuit on false
 		andShortCircuit := And(alwaysFalse, panicSpec)
 		if andShortCircuit(conflict) != false {
 			t.Errorf("And should short-circuit on false")
 		}
-		
+
 		// Or should short-circuit on true
 		orShortCircuit := Or(alwaysTrue, panicSpec)
 		if orShortCircuit(conflict) != true {
@@ -739,7 +739,7 @@ func BenchmarkLastWriteWinsResolver(b *testing.B) {
 		Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 2}},
 	}
 	ctx := context.Background()
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = resolver.Resolve(ctx, conflict)
@@ -753,7 +753,7 @@ func BenchmarkAdditiveMergeResolver(b *testing.B) {
 		Remote: EventWithVersion{Event: &testEvent{id: "remote"}, Version: &testVersion{v: 2}},
 	}
 	ctx := context.Background()
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = resolver.Resolve(ctx, conflict)
@@ -763,7 +763,7 @@ func BenchmarkAdditiveMergeResolver(b *testing.B) {
 func BenchmarkEventTypeIsSpec(b *testing.B) {
 	spec := EventTypeIs("TestEvent")
 	conflict := Conflict{EventType: "TestEvent"}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = spec(conflict)
@@ -775,13 +775,13 @@ func BenchmarkComplexSpec(b *testing.B) {
 	fieldSpec := AnyFieldIn("field1", "field2", "field3")
 	metaSpec := MetadataEq("priority", "high")
 	complexSpec := And(Or(eventTypeSpec, fieldSpec), Not(metaSpec))
-	
+
 	conflict := Conflict{
 		EventType:     "TestEvent",
 		ChangedFields: []string{"field1", "other"},
 		Metadata:      map[string]interface{}{"priority": "low"},
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = complexSpec(conflict)

--- a/synckit/spec.go
+++ b/synckit/spec.go
@@ -5,10 +5,14 @@ package synckit
 type Spec func(Conflict) bool
 
 // And returns a spec that requires both specs to match.
-func And(a, b Spec) Spec { return func(c Conflict) bool { return a != nil && b != nil && a(c) && b(c) } }
+func And(a, b Spec) Spec {
+	return func(c Conflict) bool { return a != nil && b != nil && a(c) && b(c) }
+}
 
 // Or returns a spec that requires at least one spec to match.
-func Or(a, b Spec) Spec { return func(c Conflict) bool { return (a != nil && a(c)) || (b != nil && b(c)) } }
+func Or(a, b Spec) Spec {
+	return func(c Conflict) bool { return (a != nil && a(c)) || (b != nil && b(c)) }
+}
 
 // Not returns a spec that negates the provided spec.
 func Not(a Spec) Spec { return func(c Conflict) bool { return a == nil || !a(c) } }
@@ -21,10 +25,14 @@ func EventTypeIs(t string) Spec {
 // AnyFieldIn matches when any of the conflict's changed fields is in the set.
 func AnyFieldIn(fields ...string) Spec {
 	set := map[string]struct{}{}
-	for _, f := range fields { set[f] = struct{}{} }
+	for _, f := range fields {
+		set[f] = struct{}{}
+	}
 	return func(c Conflict) bool {
 		for _, f := range c.ChangedFields {
-			if _, ok := set[f]; ok { return true }
+			if _, ok := set[f]; ok {
+				return true
+			}
 		}
 		return false
 	}
@@ -33,9 +41,13 @@ func AnyFieldIn(fields ...string) Spec {
 // MetadataEq matches when Metadata[key] equals value.
 func MetadataEq(key string, value any) Spec {
 	return func(c Conflict) bool {
-		if c.Metadata == nil { return false }
+		if c.Metadata == nil {
+			return false
+		}
 		v, ok := c.Metadata[key]
-		if !ok { return false }
+		if !ok {
+			return false
+		}
 		return anyEqual(v, value)
 	}
 }
@@ -80,15 +92,20 @@ func AndMatcher(specs ...Spec) Spec {
 func anyEqual(a, b any) bool {
 	switch av := a.(type) {
 	case string:
-		bv, ok := b.(string); return ok && av == bv
+		bv, ok := b.(string)
+		return ok && av == bv
 	case int:
-		bv, ok := b.(int); return ok && av == bv
+		bv, ok := b.(int)
+		return ok && av == bv
 	case int64:
-		bv, ok := b.(int64); return ok && av == bv
+		bv, ok := b.(int64)
+		return ok && av == bv
 	case uint64:
-		bv, ok := b.(uint64); return ok && av == bv
+		bv, ok := b.(uint64)
+		return ok && av == bv
 	case bool:
-		bv, ok := b.(bool); return ok && av == bv
+		bv, ok := b.(bool)
+		return ok && av == bv
 	default:
 		return a == b
 	}

--- a/synckit/stateful_realtime.go
+++ b/synckit/stateful_realtime.go
@@ -17,27 +17,27 @@ type StatefulRealtimeNotifier interface {
 
 // StatefulRealtimeSyncManager enhances RealtimeSyncManager with transport state awareness
 type StatefulRealtimeSyncManager struct {
-	*realtimeSyncManager // embed existing functionality
+	*realtimeSyncManager  // embed existing functionality
 	transportStateManager *statemachine.TransportStateManager
-	mu                   sync.RWMutex
+	mu                    sync.RWMutex
 }
 
 // StatefulRealtimeSyncOptions extends RealtimeSyncOptions with state machine configuration
 type StatefulRealtimeSyncOptions struct {
 	RealtimeSyncOptions
-	
+
 	// TransportStateConfig for configuring transport state management
 	TransportStateConfig statemachine.TransportStateManagerConfig
-	
+
 	// EnableTransportStateLogging enables detailed transport state logging
 	EnableTransportStateLogging bool
-	
+
 	// ConnectionTimeout for transport connection attempts
 	ConnectionTimeout time.Duration
-	
+
 	// MaxConnectionAttempts before marking transport as failed
 	MaxConnectionAttempts int
-	
+
 	// ConnectionRetryDelay between connection attempts
 	ConnectionRetryDelay time.Duration
 }
@@ -47,7 +47,7 @@ func NewStatefulRealtimeSyncManager(store EventStore, transport Transport, optio
 	if options == nil {
 		return nil, fmt.Errorf("options cannot be nil")
 	}
-	
+
 	// Set defaults
 	if options.ConnectionTimeout == 0 {
 		options.ConnectionTimeout = 30 * time.Second
@@ -58,14 +58,14 @@ func NewStatefulRealtimeSyncManager(store EventStore, transport Transport, optio
 	if options.ConnectionRetryDelay == 0 {
 		options.ConnectionRetryDelay = 2 * time.Second
 	}
-	
+
 	// Create the base realtime sync manager
 	baseManager := NewRealtimeSyncManager(store, transport, &options.RealtimeSyncOptions)
 	baseRealtime, ok := baseManager.(*realtimeSyncManager)
 	if !ok {
 		return nil, fmt.Errorf("failed to cast to realtimeSyncManager")
 	}
-	
+
 	// Setup transport state configuration
 	stateConfig := options.TransportStateConfig
 	if stateConfig.Logger == nil && baseRealtime.logger != nil {
@@ -77,21 +77,21 @@ func NewStatefulRealtimeSyncManager(store EventStore, transport Transport, optio
 	if stateConfig.Endpoint == "" {
 		stateConfig.Endpoint = "realtime_connection"
 	}
-	
+
 	// Create transport state manager
 	transportStateManager, err := statemachine.NewTransportStateManager(stateConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transport state manager: %w", err)
 	}
-	
+
 	statefulManager := &StatefulRealtimeSyncManager{
 		realtimeSyncManager:   baseRealtime,
 		transportStateManager: transportStateManager,
 	}
-	
+
 	// Subscribe to transport state changes for enhanced connection monitoring
 	transportStateManager.SubscribeToStateChanges(statefulManager.handleTransportStateChange)
-	
+
 	return statefulManager, nil
 }
 
@@ -102,17 +102,17 @@ func (srsm *StatefulRealtimeSyncManager) handleTransportStateChange(transition s
 		"to", transition.To.String(),
 		"duration", transition.Duration,
 		"metadata", transition.Metadata)
-	
+
 	switch transition.To {
 	case statemachine.TransportConnected:
 		srsm.onTransportConnected(transition)
-		
+
 	case statemachine.TransportDisconnected:
 		srsm.onTransportDisconnected(transition)
-		
+
 	case statemachine.TransportFailed:
 		srsm.onTransportFailed(transition)
-		
+
 	case statemachine.TransportReconnecting:
 		srsm.onTransportReconnecting(transition)
 	}
@@ -122,10 +122,10 @@ func (srsm *StatefulRealtimeSyncManager) handleTransportStateChange(transition s
 func (srsm *StatefulRealtimeSyncManager) onTransportConnected(transition statemachine.StateTransition[statemachine.TransportState]) {
 	// Update internal connection status
 	srsm.updateConnectionStatus(true, time.Now(), nil)
-	
+
 	// Stop fallback polling since we're now connected
 	srsm.stopFallbackPolling()
-	
+
 	// Log successful connection with metadata
 	srsm.logger.Info("Realtime transport connected successfully",
 		"connection_time", transition.Metadata["connection_time"],
@@ -139,9 +139,9 @@ func (srsm *StatefulRealtimeSyncManager) onTransportDisconnected(transition stat
 	if r, ok := transition.Metadata["disconnect_reason"].(string); ok {
 		reason = r
 	}
-	
+
 	srsm.updateConnectionStatus(false, time.Time{}, fmt.Errorf("disconnected: %s", reason))
-	
+
 	// Start fallback polling if not disabled
 	if !srsm.realtimeOptions.DisablePolling {
 		go func() {
@@ -149,7 +149,7 @@ func (srsm *StatefulRealtimeSyncManager) onTransportDisconnected(transition stat
 			srsm.startFallbackPolling(ctx)
 		}()
 	}
-	
+
 	srsm.logger.Warn("Realtime transport disconnected",
 		"reason", reason,
 		"graceful", transition.Metadata["graceful"])
@@ -162,9 +162,9 @@ func (srsm *StatefulRealtimeSyncManager) onTransportFailed(transition statemachi
 	if e, ok := transition.Metadata["error"].(string); ok {
 		errorMsg = e
 	}
-	
+
 	srsm.updateConnectionStatus(false, time.Time{}, fmt.Errorf("%s", errorMsg))
-	
+
 	// Start fallback polling if not disabled
 	if !srsm.realtimeOptions.DisablePolling {
 		go func() {
@@ -172,7 +172,7 @@ func (srsm *StatefulRealtimeSyncManager) onTransportFailed(transition statemachi
 			srsm.startFallbackPolling(ctx)
 		}()
 	}
-	
+
 	srsm.logger.Error("Realtime transport failed",
 		"error", errorMsg,
 		"total_attempts", transition.Metadata["total_attempts"],
@@ -185,17 +185,17 @@ func (srsm *StatefulRealtimeSyncManager) onTransportReconnecting(transition stat
 	if r, ok := transition.Metadata["disconnect_reason"].(string); ok {
 		reason = r
 	}
-	
+
 	attempt := 0
 	if a, ok := transition.Metadata["attempt"].(int); ok {
 		attempt = a
 	}
-	
+
 	nextRetry := time.Duration(0)
 	if nr, ok := transition.Metadata["next_retry"].(time.Duration); ok {
 		nextRetry = nr
 	}
-	
+
 	srsm.logger.Info("Realtime transport reconnecting",
 		"reason", reason,
 		"attempt", attempt,
@@ -209,16 +209,16 @@ func (srsm *StatefulRealtimeSyncManager) EnhancedEnableRealtime(ctx context.Cont
 	if !currentState.CanConnect() && currentState != statemachine.TransportDisconnected {
 		return fmt.Errorf("cannot enable realtime from transport state: %s", currentState.String())
 	}
-	
+
 	// Transition to connecting state
 	if err := srsm.transportStateManager.TransitionToConnecting(30 * time.Second); err != nil {
 		return fmt.Errorf("failed to transition to connecting state: %w", err)
 	}
-	
+
 	// Attempt to enable realtime with state tracking
 	start := time.Now()
 	err := srsm.EnableRealtime(ctx)
-	
+
 	if err != nil {
 		// Transition to failed state
 		failErr := srsm.transportStateManager.TransitionToFailed(err, 1, time.Since(start))
@@ -227,13 +227,13 @@ func (srsm *StatefulRealtimeSyncManager) EnhancedEnableRealtime(ctx context.Cont
 		}
 		return err
 	}
-	
+
 	// Transition to connected state
 	connErr := srsm.transportStateManager.TransitionToConnected(time.Since(start))
 	if connErr != nil {
 		srsm.logger.Error("Failed to transition to connected state", "error", connErr)
 	}
-	
+
 	return nil
 }
 
@@ -243,17 +243,17 @@ func (srsm *StatefulRealtimeSyncManager) EnhancedDisableRealtime() error {
 	if err := srsm.transportStateManager.TransitionToShuttingDown("realtime_disabled"); err != nil {
 		srsm.logger.Error("Failed to transition to shutting down state", "error", err)
 	}
-	
+
 	// Call base disable realtime
 	err := srsm.DisableRealtime()
-	
+
 	// After successful shutdown, transition to disconnected
 	if err == nil {
 		if transErr := srsm.transportStateManager.TransitionToDisconnected("realtime_disabled", true); transErr != nil {
 			srsm.logger.Error("Failed to transition to disconnected state", "error", transErr)
 		}
 	}
-	
+
 	return err
 }
 
@@ -293,7 +293,7 @@ func (srsm *StatefulRealtimeSyncManager) EnhancedClose() error {
 	if err := srsm.transportStateManager.Close(); err != nil {
 		srsm.logger.Error("Error closing transport state manager", "error", err)
 	}
-	
+
 	// Call base close
 	return srsm.Close()
 }
@@ -303,15 +303,15 @@ func (srsm *StatefulRealtimeSyncManager) MonitorTransportHealth(ctx context.Cont
 	if checkInterval == 0 {
 		checkInterval = 10 * time.Second
 	}
-	
+
 	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-			
+
 		case <-ticker.C:
 			srsm.performHealthCheck(ctx)
 		}
@@ -321,38 +321,38 @@ func (srsm *StatefulRealtimeSyncManager) MonitorTransportHealth(ctx context.Cont
 // performHealthCheck checks transport health and handles reconnection logic
 func (srsm *StatefulRealtimeSyncManager) performHealthCheck(ctx context.Context) {
 	currentState := srsm.transportStateManager.GetConnectionState()
-	
+
 	// Skip health checks for terminal or transitioning states
-	if currentState == statemachine.TransportShuttingDown || 
-	   currentState == statemachine.TransportConnecting ||
-	   currentState == statemachine.TransportReconnecting {
+	if currentState == statemachine.TransportShuttingDown ||
+		currentState == statemachine.TransportConnecting ||
+		currentState == statemachine.TransportReconnecting {
 		return
 	}
-	
+
 	// Check if realtime notifier is actually connected
 	if srsm.realtimeOptions.RealtimeNotifier != nil {
 		isConnected := srsm.realtimeOptions.RealtimeNotifier.IsConnected()
-		
+
 		// If state machine thinks we're connected but we're actually not, trigger reconnection
 		if currentState == statemachine.TransportConnected && !isConnected {
 			srsm.logger.Warn("Transport state mismatch detected, triggering reconnection")
-			
+
 			// Transition to reconnecting state
 			if err := srsm.transportStateManager.TransitionToReconnecting(
 				"health_check_failed", 1, 2*time.Second); err != nil {
 				srsm.logger.Error("Failed to transition to reconnecting state", "error", err)
 				return
 			}
-			
+
 			// Attempt to reconnect
 			go srsm.attemptReconnection(ctx)
 		}
-		
+
 		// If we're in disconnected/failed state but should try to connect
-		if (currentState == statemachine.TransportDisconnected || 
-		    currentState == statemachine.TransportFailed) && 
-		   srsm.IsRealtimeActive() {
-			
+		if (currentState == statemachine.TransportDisconnected ||
+			currentState == statemachine.TransportFailed) &&
+			srsm.IsRealtimeActive() {
+
 			srsm.logger.Info("Attempting to reestablish transport connection")
 			go srsm.attemptReconnection(ctx)
 		}
@@ -362,7 +362,7 @@ func (srsm *StatefulRealtimeSyncManager) performHealthCheck(ctx context.Context)
 // attemptReconnection attempts to reestablish the transport connection
 func (srsm *StatefulRealtimeSyncManager) attemptReconnection(ctx context.Context) {
 	start := time.Now()
-	
+
 	// Transition to connecting state if not already reconnecting
 	currentState := srsm.transportStateManager.GetConnectionState()
 	if currentState.CanConnect() {
@@ -371,19 +371,19 @@ func (srsm *StatefulRealtimeSyncManager) attemptReconnection(ctx context.Context
 			return
 		}
 	}
-	
+
 	// Attempt to resubscribe to notifications
 	if srsm.realtimeOptions.RealtimeNotifier != nil {
 		// First unsubscribe to clean up any existing connections
 		srsm.realtimeOptions.RealtimeNotifier.Unsubscribe()
-		
+
 		// Attempt to subscribe again
 		err := srsm.realtimeOptions.RealtimeNotifier.Subscribe(ctx, func(notification Notification) error {
 			// Handle notification (simplified for this example)
 			srsm.logger.Debug("Received notification during reconnection", "type", notification.Type)
 			return nil
 		})
-		
+
 		if err != nil {
 			// Transition to failed state
 			if failErr := srsm.transportStateManager.TransitionToFailed(err, 1, time.Since(start)); failErr != nil {
@@ -391,7 +391,7 @@ func (srsm *StatefulRealtimeSyncManager) attemptReconnection(ctx context.Context
 			}
 			return
 		}
-		
+
 		// Successful reconnection
 		if connErr := srsm.transportStateManager.TransitionToConnected(time.Since(start)); connErr != nil {
 			srsm.logger.Error("Failed to transition to connected state after reconnection", "error", connErr)
@@ -403,23 +403,23 @@ func (srsm *StatefulRealtimeSyncManager) attemptReconnection(ctx context.Context
 func (srsm *StatefulRealtimeSyncManager) GetEnhancedConnectionStatus() map[string]interface{} {
 	baseStatus := srsm.GetConnectionStatus()
 	transportMeta := srsm.GetTransportConnectionMetadata()
-	
+
 	enhanced := map[string]interface{}{
 		"base_connected":          baseStatus.Connected,
 		"base_last_connected":     baseStatus.LastConnected,
 		"base_reconnect_attempts": baseStatus.ReconnectAttempts,
-		"base_error":             baseStatus.Error,
+		"base_error":              baseStatus.Error,
 	}
-	
+
 	// Add transport state information
 	for key, value := range transportMeta {
 		enhanced["transport_"+key] = value
 	}
-	
+
 	// Add health status
 	enhanced["transport_healthy"] = srsm.IsTransportHealthy()
 	enhanced["can_send_data"] = srsm.CanSendRealtimeData()
 	enhanced["can_receive_data"] = srsm.CanReceiveRealtimeData()
-	
+
 	return enhanced
 }

--- a/synckit/stateful_resolver.go
+++ b/synckit/stateful_resolver.go
@@ -15,20 +15,20 @@ import (
 type StatefulDynamicResolver struct {
 	// Embed the existing DynamicResolver for backward compatibility
 	*DynamicResolver
-	
+
 	// State machine and workflow components
 	stateMachine    *statemachine.ConflictResolutionStateMachine
 	workflowManager *statemachine.WorkflowManager
 	options         *statemachine.StatefulResolverOptions
-	
+
 	// Performance and metrics tracking
 	performanceMetrics *statemachine.ResolverPerformanceMetrics
 	metricsLock        sync.RWMutex
-	
+
 	// Observability integration
 	stateObservers []statemachine.StateObserver[statemachine.ConflictResolutionState]
 	observerLock   sync.RWMutex
-	
+
 	// Configuration and lifecycle
 	enabled bool
 	mu      sync.RWMutex
@@ -45,29 +45,29 @@ func NewStatefulDynamicResolver(baseResolver *DynamicResolver, options *statemac
 	if baseResolver == nil {
 		return nil, errors.New("base resolver cannot be nil")
 	}
-	
+
 	if options == nil {
 		options = statemachine.DefaultStatefulResolverOptions()
 	}
-	
+
 	// Create state machine if enabled
 	var stateMachine *statemachine.ConflictResolutionStateMachine
 	if options.EnableStateMachine {
 		smConfig := &statemachine.StateMachineConfig[statemachine.ConflictResolutionState]{
-			InitialState:    statemachine.DCRIdle,
-			MaxHistorySize:  options.MaxStateHistorySize,
-			EnableMetrics:   true,
+			InitialState:   statemachine.DCRIdle,
+			MaxHistorySize: options.MaxStateHistorySize,
+			EnableMetrics:  true,
 			Name:           "StatefulDynamicResolver",
 		}
 		stateMachine = statemachine.NewConflictResolutionStateMachine(smConfig)
 	}
-	
+
 	// Create workflow manager if enabled
 	var workflowManager *statemachine.WorkflowManager
 	if options.EnableWorkflowTracking {
 		workflowManager = statemachine.NewWorkflowManager()
 	}
-	
+
 	// Initialize performance metrics
 	var performanceMetrics *statemachine.ResolverPerformanceMetrics
 	if options.EnablePerformanceMetrics {
@@ -76,17 +76,17 @@ func NewStatefulDynamicResolver(baseResolver *DynamicResolver, options *statemac
 			LastResetTime:          time.Now(),
 		}
 	}
-	
+
 	resolver := &StatefulDynamicResolver{
 		DynamicResolver:    baseResolver,
 		stateMachine:       stateMachine,
 		workflowManager:    workflowManager,
-		options:           options,
+		options:            options,
 		performanceMetrics: performanceMetrics,
-		stateObservers:    make([]statemachine.StateObserver[statemachine.ConflictResolutionState], 0),
-		enabled:           true,
+		stateObservers:     make([]statemachine.StateObserver[statemachine.ConflictResolutionState], 0),
+		enabled:            true,
 	}
-	
+
 	// Configure state machine observers if we have observability hooks
 	if options.ObservabilityHooks != nil && stateMachine != nil {
 		observer := &resolverStateObserver{
@@ -95,7 +95,7 @@ func NewStatefulDynamicResolver(baseResolver *DynamicResolver, options *statemac
 		}
 		resolver.SubscribeToStateChanges(observer)
 	}
-	
+
 	return resolver, nil
 }
 
@@ -109,38 +109,38 @@ func (sdr *StatefulDynamicResolver) Resolve(ctx context.Context, c Conflict) (Re
 		performanceTracker = statemachine.NewPerformanceTracker()
 		performanceTracker.Checkpoint("resolve_started")
 	}
-	
+
 	// Create workflow if tracking is enabled
 	var workflow *statemachine.ConflictWorkflow
 	if sdr.options.EnableWorkflowTracking && sdr.workflowManager != nil {
 		workflow = sdr.workflowManager.StartWorkflow(c, sdr.stateMachine, sdr.options.WorkflowOptions)
-		
+
 		// Trigger observability hook
 		if sdr.options.ObservabilityHooks != nil && sdr.options.ObservabilityHooks.OnWorkflowStarted != nil {
 			sdr.options.ObservabilityHooks.OnWorkflowStarted(workflow.GetCurrentStatus().ConflictID, c)
 		}
 	}
-	
+
 	// Initialize state machine for this resolution if enabled
 	if sdr.stateMachine != nil {
 		conflictID := generateConflictID(c)
 		if err := sdr.stateMachine.StartResolution(conflictID); err != nil {
 			return ResolvedConflict{}, err
 		}
-		
+
 		// Start analysis phase
 		if workflow != nil {
 			workflow.StartAnalysis()
 		}
-		
+
 		if performanceTracker != nil {
 			performanceTracker.Checkpoint("analysis_started")
 		}
 	}
-	
+
 	// Perform the actual resolution with enhanced tracking
 	result, err := sdr.resolveWithTracking(ctx, c, workflow, performanceTracker)
-	
+
 	// Complete workflow and state machine
 	if sdr.stateMachine != nil {
 		if err != nil {
@@ -155,7 +155,7 @@ func (sdr *StatefulDynamicResolver) Resolve(ctx context.Context, c Conflict) (Re
 				sdr.stateMachine.CompleteResolution()
 			}
 		}
-		
+
 		// Reset state machine for next conflict
 		defer func() {
 			if resetErr := sdr.stateMachine.Reset(); resetErr != nil && sdr.options.Logger != nil {
@@ -164,13 +164,13 @@ func (sdr *StatefulDynamicResolver) Resolve(ctx context.Context, c Conflict) (Re
 			}
 		}()
 	}
-	
+
 	// Complete workflow tracking
 	if workflow != nil {
 		if err == nil {
 			workflow.CompleteResolution(result.Decision, result.Reasons, result.ResolvedEvents)
 		}
-		
+
 		// Generate audit trail and trigger completion hook
 		if auditTrail := sdr.workflowManager.CompleteWorkflow(workflow.GetCurrentStatus().ConflictID); auditTrail != nil {
 			if sdr.options.ObservabilityHooks != nil && sdr.options.ObservabilityHooks.OnWorkflowCompleted != nil {
@@ -178,12 +178,12 @@ func (sdr *StatefulDynamicResolver) Resolve(ctx context.Context, c Conflict) (Re
 			}
 		}
 	}
-	
+
 	// Update performance metrics
 	if performanceTracker != nil && sdr.performanceMetrics != nil {
 		sdr.updatePerformanceMetrics(performanceTracker, result, err)
 	}
-	
+
 	return result, err
 }
 
@@ -195,15 +195,15 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 			return ResolvedConflict{}, err
 		}
 	}
-	
+
 	if tracker != nil {
 		tracker.Checkpoint("rules_started")
 	}
-	
+
 	// Evaluate rules with enhanced tracking
 	for _, r := range sdr.rules {
 		ruleStart := time.Now()
-		
+
 		// Trigger rule evaluation hook
 		if sdr.options.ObservabilityHooks != nil && sdr.options.ObservabilityHooks.OnRuleEvaluationStarted != nil {
 			conflictID := ""
@@ -212,21 +212,21 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 			}
 			sdr.options.ObservabilityHooks.OnRuleEvaluationStarted(conflictID, r.Name)
 		}
-		
+
 		// Track rule evaluation in state machine
 		if sdr.stateMachine != nil {
 			sdr.stateMachine.RecordRuleEvaluation(r.Name)
 		}
-		
+
 		// Evaluate the rule
 		matched := r.Matcher != nil && r.Matcher(c)
 		ruleDuration := time.Since(ruleStart)
-		
+
 		// Record rule evaluation in workflow
 		if workflow != nil {
 			workflow.RecordRuleEvaluation(r.Name, matched, ruleDuration, nil, nil)
 		}
-		
+
 		// Trigger rule evaluation completed hook
 		if sdr.options.ObservabilityHooks != nil && sdr.options.ObservabilityHooks.OnRuleEvaluationCompleted != nil {
 			conflictID := ""
@@ -235,18 +235,18 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 			}
 			sdr.options.ObservabilityHooks.OnRuleEvaluationCompleted(conflictID, r.Name, matched, ruleDuration)
 		}
-		
+
 		if matched {
 			// Record rule match in state machine
 			if sdr.stateMachine != nil {
 				sdr.stateMachine.RecordRuleMatched(r.Name)
 			}
-			
+
 			// Call original hook for backward compatibility
 			if sdr.hooks.OnRuleMatched != nil {
 				sdr.hooks.OnRuleMatched(c, r)
 			}
-			
+
 			// Resolve using the matched rule
 			res, err := r.Resolver.Resolve(ctx, c)
 			if err != nil {
@@ -254,11 +254,11 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 				if sdr.stateMachine != nil {
 					sdr.stateMachine.RecordRuleFailed(r.Name)
 				}
-				
+
 				if workflow != nil {
 					workflow.RecordRuleEvaluation(r.Name, true, ruleDuration, err, nil)
 				}
-				
+
 				// Trigger rule evaluation failed hook
 				if sdr.options.ObservabilityHooks != nil && sdr.options.ObservabilityHooks.OnRuleEvaluationFailed != nil {
 					conflictID := ""
@@ -267,50 +267,50 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 					}
 					sdr.options.ObservabilityHooks.OnRuleEvaluationFailed(conflictID, r.Name, err)
 				}
-				
+
 				// Call original error hook for backward compatibility
 				if sdr.hooks.OnError != nil {
 					sdr.hooks.OnError(c, err)
 				}
-				
+
 				return ResolvedConflict{}, err
 			}
-			
+
 			// Call original resolved hook for backward compatibility
 			if sdr.hooks.OnResolved != nil {
 				sdr.hooks.OnResolved(c, res)
 			}
-			
+
 			if tracker != nil {
 				tracker.Checkpoint("resolution_completed")
 				tracker.Increment("rules_matched")
 			}
-			
+
 			return res, nil
 		}
-		
+
 		if tracker != nil {
 			tracker.Increment("rules_evaluated")
 		}
 	}
-	
+
 	// No rule matched, try fallback
 	if sdr.fallback == nil {
 		err := errors.New("no rule matched and no fallback configured")
-		
+
 		// Call original error hook for backward compatibility
 		if sdr.hooks.OnError != nil {
 			sdr.hooks.OnError(c, err)
 		}
-		
+
 		return ResolvedConflict{}, err
 	}
-	
+
 	// Call original fallback hook for backward compatibility
 	if sdr.hooks.OnFallback != nil {
 		sdr.hooks.OnFallback(c)
 	}
-	
+
 	// Execute fallback
 	res, err := sdr.fallback.Resolve(ctx, c)
 	if err != nil {
@@ -318,20 +318,20 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 		if sdr.hooks.OnError != nil {
 			sdr.hooks.OnError(c, err)
 		}
-		
+
 		return ResolvedConflict{}, err
 	}
-	
+
 	// Call original resolved hook for backward compatibility
 	if sdr.hooks.OnResolved != nil {
 		sdr.hooks.OnResolved(c, res)
 	}
-	
+
 	if tracker != nil {
 		tracker.Checkpoint("fallback_completed")
 		tracker.Increment("fallback_used")
 	}
-	
+
 	return res, nil
 }
 
@@ -339,22 +339,22 @@ func (sdr *StatefulDynamicResolver) resolveWithTracking(ctx context.Context, c C
 func (sdr *StatefulDynamicResolver) updatePerformanceMetrics(tracker *statemachine.PerformanceTracker, result ResolvedConflict, err error) {
 	sdr.metricsLock.Lock()
 	defer sdr.metricsLock.Unlock()
-	
+
 	if sdr.performanceMetrics == nil {
 		return
 	}
-	
+
 	totalDuration := tracker.GetTotalDuration()
-	
+
 	// Update overall statistics
 	sdr.performanceMetrics.TotalConflictsResolved++
 	sdr.performanceMetrics.TotalResolutionTime += totalDuration
-	
+
 	// Calculate average resolution time correctly
 	if sdr.performanceMetrics.TotalConflictsResolved > 0 {
 		sdr.performanceMetrics.AverageResolutionTime = time.Duration(int64(sdr.performanceMetrics.TotalResolutionTime) / sdr.performanceMetrics.TotalConflictsResolved)
 	}
-	
+
 	// Update min/max resolution times
 	if sdr.performanceMetrics.FastestResolutionTime == 0 || totalDuration < sdr.performanceMetrics.FastestResolutionTime {
 		sdr.performanceMetrics.FastestResolutionTime = totalDuration
@@ -362,7 +362,7 @@ func (sdr *StatefulDynamicResolver) updatePerformanceMetrics(tracker *statemachi
 	if totalDuration > sdr.performanceMetrics.SlowestResolutionTime {
 		sdr.performanceMetrics.SlowestResolutionTime = totalDuration
 	}
-	
+
 	// Update resolution outcome counters
 	if err != nil {
 		sdr.performanceMetrics.FailedCount++
@@ -376,11 +376,11 @@ func (sdr *StatefulDynamicResolver) updatePerformanceMetrics(tracker *statemachi
 			sdr.performanceMetrics.AutoResolvedCount++
 		}
 	}
-	
+
 	// Update rule performance metrics
 	sdr.performanceMetrics.RuleEvaluationCount += tracker.GetCounter("rules_evaluated")
 	sdr.performanceMetrics.RuleMatchCount += tracker.GetCounter("rules_matched")
-	
+
 	// Trigger metrics recorded hook
 	if sdr.options.ObservabilityHooks != nil && sdr.options.ObservabilityHooks.OnMetricsRecorded != nil {
 		sdr.options.ObservabilityHooks.OnMetricsRecorded(sdr.performanceMetrics)
@@ -406,9 +406,9 @@ func (sdr *StatefulDynamicResolver) GetStateHistory() []statemachine.StateTransi
 func (sdr *StatefulDynamicResolver) SubscribeToStateChanges(observer statemachine.StateObserver[statemachine.ConflictResolutionState]) {
 	sdr.observerLock.Lock()
 	defer sdr.observerLock.Unlock()
-	
+
 	sdr.stateObservers = append(sdr.stateObservers, observer)
-	
+
 	if sdr.stateMachine != nil {
 		sdr.stateMachine.Subscribe(observer)
 	}
@@ -436,12 +436,12 @@ func (sdr *StatefulDynamicResolver) GetAuditTrail(conflictID string) (*statemach
 	if sdr.workflowManager == nil {
 		return nil, errors.New("workflow tracking is not enabled")
 	}
-	
+
 	// Try to get active workflow first
 	if workflow, exists := sdr.workflowManager.GetWorkflow(conflictID); exists {
 		return workflow.GenerateAuditTrail(), nil
 	}
-	
+
 	// If not found in active workflows, it might be completed
 	// In a real implementation, you might want to store completed audit trails
 	return nil, errors.New("audit trail not found for conflict ID: " + conflictID)
@@ -450,11 +450,11 @@ func (sdr *StatefulDynamicResolver) GetAuditTrail(conflictID string) (*statemach
 func (sdr *StatefulDynamicResolver) Configure(options *statemachine.StatefulResolverOptions) error {
 	sdr.mu.Lock()
 	defer sdr.mu.Unlock()
-	
+
 	if options == nil {
 		return errors.New("options cannot be nil")
 	}
-	
+
 	sdr.options = options
 	return nil
 }
@@ -466,17 +466,17 @@ func (sdr *StatefulDynamicResolver) IsStateMachineEnabled() bool {
 func (sdr *StatefulDynamicResolver) GetPerformanceMetrics() *statemachine.ResolverPerformanceMetrics {
 	sdr.metricsLock.RLock()
 	defer sdr.metricsLock.RUnlock()
-	
+
 	if sdr.performanceMetrics == nil {
 		return nil
 	}
-	
+
 	// Return a copy to prevent external modification
 	metricsCopy := *sdr.performanceMetrics
 	if sdr.workflowManager != nil {
 		metricsCopy.CurrentActiveWorkflows = len(sdr.workflowManager.ListActiveWorkflows())
 	}
-	
+
 	return &metricsCopy
 }
 
@@ -505,7 +505,7 @@ func NewStatefulDynamicResolverFromOptions(dynamicOpts []Option, statefulOpts *s
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return NewStatefulDynamicResolver(baseResolver, statefulOpts)
 }
 

--- a/synckit/stateful_resolver_test.go
+++ b/synckit/stateful_resolver_test.go
@@ -14,9 +14,9 @@ import (
 
 // mockStatefulResolver is a test double for testing StatefulDynamicResolver
 type mockStatefulResolver struct {
-	name string
-	res  ResolvedConflict
-	err  error
+	name  string
+	res   ResolvedConflict
+	err   error
 	calls int
 }
 
@@ -52,8 +52,8 @@ func (s *slowResolver) Resolve(ctx context.Context, c Conflict) (ResolvedConflic
 type testObservabilityHooks struct {
 	mu sync.Mutex
 
-	stateTransitions          []stateTransitionCall
-	stateTransitionFailures   []stateTransitionFailureCall
+	stateTransitions         []stateTransitionCall
+	stateTransitionFailures  []stateTransitionFailureCall
 	workflowsStarted         []workflowStartedCall
 	workflowsCompleted       []workflowCompletedCall
 	workflowsFailed          []workflowFailedCall
@@ -81,8 +81,8 @@ type workflowStartedCall struct {
 }
 
 type workflowCompletedCall struct {
-	conflictID  string
-	auditTrail  *statemachine.ConflictAuditTrail
+	conflictID string
+	auditTrail *statemachine.ConflictAuditTrail
 }
 
 type workflowFailedCall struct {
@@ -114,8 +114,8 @@ type metricsRecordedCall struct {
 
 func newTestObservabilityHooks() *testObservabilityHooks {
 	hooks := &testObservabilityHooks{
-		stateTransitions:          make([]stateTransitionCall, 0),
-		stateTransitionFailures:   make([]stateTransitionFailureCall, 0),
+		stateTransitions:         make([]stateTransitionCall, 0),
+		stateTransitionFailures:  make([]stateTransitionFailureCall, 0),
 		workflowsStarted:         make([]workflowStartedCall, 0),
 		workflowsCompleted:       make([]workflowCompletedCall, 0),
 		workflowsFailed:          make([]workflowFailedCall, 0),
@@ -276,9 +276,9 @@ func TestStatefulDynamicResolver_StateTransitions(t *testing.T) {
 		EnableWorkflowTracking:   true,
 		EnablePerformanceMetrics: true,
 		EnableAuditTrail:         true,
-		ObservabilityHooks:      testHooks.toConflictResolutionObservabilityHooks(),
-		WorkflowOptions:         statemachine.DefaultWorkflowOptions(),
-		MaxStateHistorySize:     100,
+		ObservabilityHooks:       testHooks.toConflictResolutionObservabilityHooks(),
+		WorkflowOptions:          statemachine.DefaultWorkflowOptions(),
+		MaxStateHistorySize:      100,
 	}
 
 	statefulResolver, err := NewStatefulDynamicResolver(dynamicResolver, options)
@@ -348,7 +348,7 @@ func TestStatefulDynamicResolver_RuleEvaluation(t *testing.T) {
 		EnableStateMachine:       true,
 		EnableWorkflowTracking:   true,
 		EnablePerformanceMetrics: true,
-		ObservabilityHooks:      testHooks.toConflictResolutionObservabilityHooks(),
+		ObservabilityHooks:       testHooks.toConflictResolutionObservabilityHooks(),
 	}
 
 	statefulResolver, err := NewStatefulDynamicResolver(dynamicResolver, options)
@@ -413,7 +413,7 @@ func TestStatefulDynamicResolver_RuleFailure(t *testing.T) {
 		EnableStateMachine:       true,
 		EnableWorkflowTracking:   true,
 		EnablePerformanceMetrics: true,
-		ObservabilityHooks:      testHooks.toConflictResolutionObservabilityHooks(),
+		ObservabilityHooks:       testHooks.toConflictResolutionObservabilityHooks(),
 	}
 
 	statefulResolver, err := NewStatefulDynamicResolver(dynamicResolver, options)
@@ -512,7 +512,7 @@ func TestStatefulDynamicResolver_PerformanceMetrics(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	
+
 	// Resolve multiple conflicts to generate metrics
 	for i := 0; i < 3; i++ {
 		_, err = statefulResolver.Resolve(ctx, conflict)
@@ -557,8 +557,8 @@ func TestStatefulDynamicResolver_WorkflowTracking(t *testing.T) {
 	}
 
 	conflict := Conflict{
-		EventType:   "TestEvent",
-		AggregateID: "test-123",
+		EventType:     "TestEvent",
+		AggregateID:   "test-123",
 		ChangedFields: []string{"field1", "field2"},
 	}
 
@@ -688,32 +688,32 @@ func TestStatefulDynamicResolver_Configuration(t *testing.T) {
 
 func TestNewStatefulDynamicResolverFromOptions(t *testing.T) {
 	baseResolver := &mockStatefulResolver{name: "base", res: ResolvedConflict{Decision: "resolved"}}
-	
+
 	dynamicOpts := []Option{
 		WithFallback(baseResolver),
 		WithRule("test_rule", AlwaysMatch(), baseResolver),
 	}
-	
+
 	statefulOpts := statemachine.DefaultStatefulResolverOptions()
-	
+
 	statefulResolver, err := NewStatefulDynamicResolverFromOptions(dynamicOpts, statefulOpts)
 	if err != nil {
 		t.Fatalf("Failed to create stateful resolver from options: %v", err)
 	}
-	
+
 	if !statefulResolver.IsStateMachineEnabled() {
 		t.Error("Expected state machine to be enabled")
 	}
-	
+
 	// Test that it works
 	conflict := Conflict{
 		EventType:   "TestEvent",
 		AggregateID: "test-123",
 	}
-	
+
 	ctx := context.Background()
 	result, err := statefulResolver.Resolve(ctx, conflict)
-	
+
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}

--- a/synckit/statemachine/conflict_workflow.go
+++ b/synckit/statemachine/conflict_workflow.go
@@ -13,11 +13,11 @@ import (
 // providing comprehensive audit trails and workflow state management.
 type ConflictWorkflow struct {
 	// Core conflict information
-	conflict      types.Conflict
-	conflictID    string
-	startTime     time.Time
-	endTime       time.Time
-	
+	conflict   types.Conflict
+	conflictID string
+	startTime  time.Time
+	endTime    time.Time
+
 	// Resolution process tracking
 	rulesEvaluated []RuleEvaluation
 	rulesMatched   []string
@@ -25,68 +25,68 @@ type ConflictWorkflow struct {
 	decision       string
 	reasons        []string
 	resolvedEvents []types.EventWithVersion
-	
+
 	// State machine integration
 	stateMachine *ConflictResolutionStateMachine
 	stateHistory []StateTransition[ConflictResolutionState]
-	
+
 	// Analysis and metadata
 	analysisResults    map[string]interface{}
 	performanceMetrics WorkflowPerformanceMetrics
-	
+
 	// Thread safety
 	mu sync.RWMutex
 }
 
 // RuleEvaluation records the evaluation of a single rule
 type RuleEvaluation struct {
-	RuleName      string                 `json:"rule_name"`
-	Matched       bool                   `json:"matched"`
-	EvaluatedAt   time.Time              `json:"evaluated_at"`
-	Duration      time.Duration          `json:"duration"`
-	Error         error                  `json:"error,omitempty"`
-	Metadata      map[string]interface{} `json:"metadata,omitempty"`
+	RuleName    string                 `json:"rule_name"`
+	Matched     bool                   `json:"matched"`
+	EvaluatedAt time.Time              `json:"evaluated_at"`
+	Duration    time.Duration          `json:"duration"`
+	Error       error                  `json:"error,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // RuleFailure records when a rule failed during execution
 type RuleFailure struct {
-	RuleName    string                 `json:"rule_name"`
-	Error       error                  `json:"error"`
-	FailedAt    time.Time              `json:"failed_at"`
-	Context     string                 `json:"context"`
-	Retryable   bool                   `json:"retryable"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	RuleName  string                 `json:"rule_name"`
+	Error     error                  `json:"error"`
+	FailedAt  time.Time              `json:"failed_at"`
+	Context   string                 `json:"context"`
+	Retryable bool                   `json:"retryable"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // WorkflowPerformanceMetrics tracks performance data for the resolution process
 type WorkflowPerformanceMetrics struct {
-	TotalDuration     time.Duration `json:"total_duration"`
-	AnalysisDuration  time.Duration `json:"analysis_duration"`
-	RulesDuration     time.Duration `json:"rules_duration"`
+	TotalDuration      time.Duration `json:"total_duration"`
+	AnalysisDuration   time.Duration `json:"analysis_duration"`
+	RulesDuration      time.Duration `json:"rules_duration"`
 	ResolutionDuration time.Duration `json:"resolution_duration"`
-	RulesEvaluated    int           `json:"rules_evaluated"`
-	RulesMatched      int           `json:"rules_matched"`
-	RulesFailed       int           `json:"rules_failed"`
-	MemoryUsage       int64         `json:"memory_usage_bytes"`
+	RulesEvaluated     int           `json:"rules_evaluated"`
+	RulesMatched       int           `json:"rules_matched"`
+	RulesFailed        int           `json:"rules_failed"`
+	MemoryUsage        int64         `json:"memory_usage_bytes"`
 }
 
 // WorkflowOptions configures the workflow tracking behavior
 type WorkflowOptions struct {
 	EnableDetailedTracking bool
-	MaxRuleEvaluations    int
-	MaxStateHistory       int
-	TrackPerformance      bool
-	IncludeMetadata       bool
+	MaxRuleEvaluations     int
+	MaxStateHistory        int
+	TrackPerformance       bool
+	IncludeMetadata        bool
 }
 
 // DefaultWorkflowOptions returns sensible defaults for workflow configuration
 func DefaultWorkflowOptions() *WorkflowOptions {
 	return &WorkflowOptions{
 		EnableDetailedTracking: true,
-		MaxRuleEvaluations:    100,
-		MaxStateHistory:       50,
-		TrackPerformance:      true,
-		IncludeMetadata:       true,
+		MaxRuleEvaluations:     100,
+		MaxStateHistory:        50,
+		TrackPerformance:       true,
+		IncludeMetadata:        true,
 	}
 }
 
@@ -97,7 +97,7 @@ func NewConflictWorkflow(conflict types.Conflict, stateMachine *ConflictResoluti
 	}
 
 	conflictID := generateConflictID(conflict)
-	
+
 	return &ConflictWorkflow{
 		conflict:           conflict,
 		conflictID:         conflictID,
@@ -118,17 +118,17 @@ func NewConflictWorkflow(conflict types.Conflict, stateMachine *ConflictResoluti
 func (cw *ConflictWorkflow) StartAnalysis() {
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
-	
+
 	analysisStart := time.Now()
 	cw.performanceMetrics.AnalysisDuration = analysisStart.Sub(cw.startTime)
-	
+
 	// Add basic analysis metadata
 	cw.analysisResults["conflict_type"] = cw.conflict.EventType
 	cw.analysisResults["aggregate_id"] = cw.conflict.AggregateID
 	cw.analysisResults["changed_fields_count"] = len(cw.conflict.ChangedFields)
 	cw.analysisResults["has_local_version"] = cw.conflict.Local.Version != nil
 	cw.analysisResults["has_remote_version"] = cw.conflict.Remote.Version != nil
-	
+
 	// Version comparison analysis
 	if cw.conflict.Local.Version != nil && cw.conflict.Remote.Version != nil {
 		comparison := cw.conflict.Local.Version.Compare(cw.conflict.Remote.Version)
@@ -148,7 +148,7 @@ func (cw *ConflictWorkflow) StartAnalysis() {
 func (cw *ConflictWorkflow) RecordRuleEvaluation(ruleName string, matched bool, duration time.Duration, err error, metadata map[string]interface{}) {
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
-	
+
 	evaluation := RuleEvaluation{
 		RuleName:    ruleName,
 		Matched:     matched,
@@ -157,15 +157,15 @@ func (cw *ConflictWorkflow) RecordRuleEvaluation(ruleName string, matched bool, 
 		Error:       err,
 		Metadata:    metadata,
 	}
-	
+
 	cw.rulesEvaluated = append(cw.rulesEvaluated, evaluation)
 	cw.performanceMetrics.RulesEvaluated++
-	
+
 	if matched {
 		cw.rulesMatched = append(cw.rulesMatched, ruleName)
 		cw.performanceMetrics.RulesMatched++
 	}
-	
+
 	if err != nil {
 		failure := RuleFailure{
 			RuleName:  ruleName,
@@ -184,7 +184,7 @@ func (cw *ConflictWorkflow) RecordRuleEvaluation(ruleName string, matched bool, 
 func (cw *ConflictWorkflow) RecordStateTransition(from, to ConflictResolutionState, duration time.Duration, metadata map[string]interface{}) {
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
-	
+
 	transition := StateTransition[ConflictResolutionState]{
 		From:      from,
 		To:        to,
@@ -192,7 +192,7 @@ func (cw *ConflictWorkflow) RecordStateTransition(from, to ConflictResolutionSta
 		Duration:  duration,
 		Metadata:  metadata,
 	}
-	
+
 	cw.stateHistory = append(cw.stateHistory, transition)
 }
 
@@ -200,12 +200,12 @@ func (cw *ConflictWorkflow) RecordStateTransition(from, to ConflictResolutionSta
 func (cw *ConflictWorkflow) CompleteResolution(decision string, reasons []string, resolvedEvents []types.EventWithVersion) {
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
-	
+
 	cw.endTime = time.Now()
 	cw.decision = decision
 	cw.reasons = append(cw.reasons, reasons...)
 	cw.resolvedEvents = append(cw.resolvedEvents, resolvedEvents...)
-	
+
 	// Update performance metrics
 	cw.performanceMetrics.TotalDuration = cw.endTime.Sub(cw.startTime)
 	cw.performanceMetrics.ResolutionDuration = time.Since(cw.endTime.Add(-cw.performanceMetrics.RulesDuration))
@@ -215,7 +215,7 @@ func (cw *ConflictWorkflow) CompleteResolution(decision string, reasons []string
 func (cw *ConflictWorkflow) GenerateAuditTrail() *ConflictAuditTrail {
 	cw.mu.RLock()
 	defer cw.mu.RUnlock()
-	
+
 	return &ConflictAuditTrail{
 		ConflictID:         cw.conflictID,
 		Timestamp:          cw.startTime,
@@ -239,55 +239,55 @@ func (cw *ConflictWorkflow) GenerateAuditTrail() *ConflictAuditTrail {
 func (cw *ConflictWorkflow) GetCurrentStatus() *WorkflowStatus {
 	cw.mu.RLock()
 	defer cw.mu.RUnlock()
-	
+
 	currentState := DCRIdle
 	if cw.stateMachine != nil {
 		currentState = cw.stateMachine.Current()
 	}
-	
+
 	return &WorkflowStatus{
-		ConflictID:         cw.conflictID,
-		CurrentState:       currentState,
-		Duration:           time.Since(cw.startTime),
-		RulesEvaluated:     len(cw.rulesEvaluated),
-		RulesMatched:       len(cw.rulesMatched),
-		RulesFailed:        len(cw.rulesFailed),
-		Decision:           cw.decision,
-		IsComplete:         !cw.endTime.IsZero(),
-		LastActivity:       cw.getLastActivityTime(),
+		ConflictID:     cw.conflictID,
+		CurrentState:   currentState,
+		Duration:       time.Since(cw.startTime),
+		RulesEvaluated: len(cw.rulesEvaluated),
+		RulesMatched:   len(cw.rulesMatched),
+		RulesFailed:    len(cw.rulesFailed),
+		Decision:       cw.decision,
+		IsComplete:     !cw.endTime.IsZero(),
+		LastActivity:   cw.getLastActivityTime(),
 	}
 }
 
 // ConflictAuditTrail provides a complete audit record of the conflict resolution process
 type ConflictAuditTrail struct {
-	ConflictID         string                                      `json:"conflict_id"`
-	Timestamp          time.Time                                   `json:"timestamp"`
-	CompletedAt        time.Time                                   `json:"completed_at"`
-	EventType          string                                      `json:"event_type"`
-	AggregateID        string                                      `json:"aggregate_id"`
-	ChangedFields      []string                                    `json:"changed_fields"`
-	Decision           string                                      `json:"decision"`
-	Reasons            []string                                    `json:"reasons"`
+	ConflictID         string                                     `json:"conflict_id"`
+	Timestamp          time.Time                                  `json:"timestamp"`
+	CompletedAt        time.Time                                  `json:"completed_at"`
+	EventType          string                                     `json:"event_type"`
+	AggregateID        string                                     `json:"aggregate_id"`
+	ChangedFields      []string                                   `json:"changed_fields"`
+	Decision           string                                     `json:"decision"`
+	Reasons            []string                                   `json:"reasons"`
 	RulesEvaluated     []RuleEvaluation                           `json:"rules_evaluated"`
-	RulesMatched       []string                                    `json:"rules_matched"`
+	RulesMatched       []string                                   `json:"rules_matched"`
 	RulesFailed        []RuleFailure                              `json:"rules_failed"`
 	StateHistory       []StateTransition[ConflictResolutionState] `json:"state_history"`
 	AnalysisResults    map[string]interface{}                     `json:"analysis_results"`
 	PerformanceMetrics WorkflowPerformanceMetrics                 `json:"performance_metrics"`
-	ResolvedEvents     []types.EventWithVersion                 `json:"resolved_events"`
+	ResolvedEvents     []types.EventWithVersion                   `json:"resolved_events"`
 }
 
 // WorkflowStatus provides real-time status information about a workflow
 type WorkflowStatus struct {
-	ConflictID     string                    `json:"conflict_id"`
-	CurrentState   ConflictResolutionState   `json:"current_state"`
-	Duration       time.Duration             `json:"duration"`
-	RulesEvaluated int                       `json:"rules_evaluated"`
-	RulesMatched   int                       `json:"rules_matched"`
-	RulesFailed    int                       `json:"rules_failed"`
-	Decision       string                    `json:"decision"`
-	IsComplete     bool                      `json:"is_complete"`
-	LastActivity   time.Time                 `json:"last_activity"`
+	ConflictID     string                  `json:"conflict_id"`
+	CurrentState   ConflictResolutionState `json:"current_state"`
+	Duration       time.Duration           `json:"duration"`
+	RulesEvaluated int                     `json:"rules_evaluated"`
+	RulesMatched   int                     `json:"rules_matched"`
+	RulesFailed    int                     `json:"rules_failed"`
+	Decision       string                  `json:"decision"`
+	IsComplete     bool                    `json:"is_complete"`
+	LastActivity   time.Time               `json:"last_activity"`
 }
 
 // WorkflowManager manages multiple concurrent conflict workflows
@@ -306,10 +306,10 @@ func NewWorkflowManager() *WorkflowManager {
 // StartWorkflow begins tracking a new conflict resolution workflow
 func (wm *WorkflowManager) StartWorkflow(conflict types.Conflict, stateMachine *ConflictResolutionStateMachine, options *WorkflowOptions) *ConflictWorkflow {
 	workflow := NewConflictWorkflow(conflict, stateMachine, options)
-	
+
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
-	
+
 	wm.workflows[workflow.conflictID] = workflow
 	return workflow
 }
@@ -318,7 +318,7 @@ func (wm *WorkflowManager) StartWorkflow(conflict types.Conflict, stateMachine *
 func (wm *WorkflowManager) GetWorkflow(conflictID string) (*ConflictWorkflow, bool) {
 	wm.mu.RLock()
 	defer wm.mu.RUnlock()
-	
+
 	workflow, exists := wm.workflows[conflictID]
 	return workflow, exists
 }
@@ -327,15 +327,15 @@ func (wm *WorkflowManager) GetWorkflow(conflictID string) (*ConflictWorkflow, bo
 func (wm *WorkflowManager) CompleteWorkflow(conflictID string) *ConflictAuditTrail {
 	wm.mu.Lock()
 	defer wm.mu.Unlock()
-	
+
 	workflow, exists := wm.workflows[conflictID]
 	if !exists {
 		return nil
 	}
-	
+
 	auditTrail := workflow.GenerateAuditTrail()
 	delete(wm.workflows, conflictID)
-	
+
 	return auditTrail
 }
 
@@ -343,12 +343,12 @@ func (wm *WorkflowManager) CompleteWorkflow(conflictID string) *ConflictAuditTra
 func (wm *WorkflowManager) ListActiveWorkflows() []*WorkflowStatus {
 	wm.mu.RLock()
 	defer wm.mu.RUnlock()
-	
+
 	statuses := make([]*WorkflowStatus, 0, len(wm.workflows))
 	for _, workflow := range wm.workflows {
 		statuses = append(statuses, workflow.GetCurrentStatus())
 	}
-	
+
 	return statuses
 }
 
@@ -362,12 +362,12 @@ func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	
+
 	// Check for context cancellation or timeout (not retryable)
 	if err == context.Canceled || err == context.DeadlineExceeded {
 		return false
 	}
-	
+
 	// Add more sophisticated error classification as needed
 	return true
 }
@@ -381,4 +381,3 @@ func (cw *ConflictWorkflow) getLastActivityTime() time.Time {
 	}
 	return cw.startTime
 }
-

--- a/synckit/statemachine/dcr_state.go
+++ b/synckit/statemachine/dcr_state.go
@@ -11,22 +11,22 @@ type ConflictResolutionState int
 const (
 	// DCRIdle indicates the conflict resolver is idle and ready for new conflicts
 	DCRIdle ConflictResolutionState = iota
-	
+
 	// DCRAnalyzing indicates the conflict is being analyzed and metadata extracted
 	DCRAnalyzing
-	
+
 	// DCRApplyingRules indicates rules are being evaluated and applied to the conflict
 	DCRApplyingRules
-	
+
 	// DCRResolved indicates the conflict was successfully resolved automatically
 	DCRResolved
-	
+
 	// DCRManualReview indicates the conflict requires manual review
 	DCRManualReview
-	
+
 	// DCREscalated indicates the conflict was escalated to a higher authority
 	DCREscalated
-	
+
 	// DCRFailed indicates the conflict resolution process failed
 	DCRFailed
 )
@@ -56,15 +56,15 @@ func (s ConflictResolutionState) String() string {
 // ConflictResolutionStateMachine manages the state of conflict resolution processes
 type ConflictResolutionStateMachine struct {
 	stateMachine StateMachine[ConflictResolutionState]
-	
+
 	// Additional conflict resolution specific state
 	currentConflictID string
-	resolutionPath    []string              // Track which rules were applied
-	matchedRules      []string              // Track which rules matched
-	failedRules       []string              // Track which rules failed
+	resolutionPath    []string // Track which rules were applied
+	matchedRules      []string // Track which rules matched
+	failedRules       []string // Track which rules failed
 	startTime         time.Time
 	analysisMetadata  map[string]interface{}
-	
+
 	// Thread safety
 	mu sync.RWMutex
 }
@@ -74,33 +74,33 @@ func NewConflictResolutionStateMachine(config *StateMachineConfig[ConflictResolu
 	if config == nil {
 		// Define valid state transitions for conflict resolution
 		transitionRules := TransitionRules[ConflictResolutionState]{
-			DCRIdle: {DCRAnalyzing},
-			DCRAnalyzing: {DCRApplyingRules, DCRFailed},
+			DCRIdle:          {DCRAnalyzing},
+			DCRAnalyzing:     {DCRApplyingRules, DCRFailed},
 			DCRApplyingRules: {DCRResolved, DCRManualReview, DCREscalated, DCRFailed},
-			DCRResolved: {DCRIdle},
-			DCRManualReview: {DCRResolved, DCREscalated, DCRFailed, DCRIdle},
-			DCREscalated: {DCRResolved, DCRFailed, DCRIdle},
-			DCRFailed: {DCRIdle},
+			DCRResolved:      {DCRIdle},
+			DCRManualReview:  {DCRResolved, DCREscalated, DCRFailed, DCRIdle},
+			DCREscalated:     {DCRResolved, DCRFailed, DCRIdle},
+			DCRFailed:        {DCRIdle},
 		}
 		config = &StateMachineConfig[ConflictResolutionState]{
 			InitialState:    DCRIdle,
 			TransitionRules: transitionRules,
 			MaxHistorySize:  100,
 			EnableMetrics:   true,
-			Name:           "ConflictResolutionStateMachine",
+			Name:            "ConflictResolutionStateMachine",
 		}
 	}
 
 	// Define valid state transitions for conflict resolution if not provided
 	if config.TransitionRules == nil {
 		config.TransitionRules = TransitionRules[ConflictResolutionState]{
-			DCRIdle: {DCRAnalyzing},
-			DCRAnalyzing: {DCRApplyingRules, DCRFailed},
+			DCRIdle:          {DCRAnalyzing},
+			DCRAnalyzing:     {DCRApplyingRules, DCRFailed},
 			DCRApplyingRules: {DCRResolved, DCRManualReview, DCREscalated, DCRFailed},
-			DCRResolved: {DCRIdle},
-			DCRManualReview: {DCRResolved, DCREscalated, DCRFailed, DCRIdle},
-			DCREscalated: {DCRResolved, DCRFailed, DCRIdle},
-			DCRFailed: {DCRIdle},
+			DCRResolved:      {DCRIdle},
+			DCRManualReview:  {DCRResolved, DCREscalated, DCRFailed, DCRIdle},
+			DCREscalated:     {DCRResolved, DCRFailed, DCRIdle},
+			DCRFailed:        {DCRIdle},
 		}
 	}
 
@@ -111,7 +111,7 @@ func NewConflictResolutionStateMachine(config *StateMachineConfig[ConflictResolu
 		fallbackConfig.Name = "ConflictResolutionStateMachine"
 		sm, _ = New(fallbackConfig)
 	}
-	
+
 	return &ConflictResolutionStateMachine{
 		stateMachine:     sm,
 		resolutionPath:   make([]string, 0),
@@ -241,14 +241,14 @@ func (sm *ConflictResolutionStateMachine) GetResolutionSummary() *ConflictResolu
 
 // ConflictResolutionSummary provides a summary of a conflict resolution process
 type ConflictResolutionSummary struct {
-	ConflictID       string                    `json:"conflict_id"`
-	CurrentState     ConflictResolutionState   `json:"current_state"`
-	ResolutionPath   []string                  `json:"resolution_path"`
-	MatchedRules     []string                  `json:"matched_rules"`
-	FailedRules      []string                  `json:"failed_rules"`
-	AnalysisMetadata map[string]interface{}    `json:"analysis_metadata"`
-	Duration         time.Duration             `json:"duration"`
-	StartTime        time.Time                 `json:"start_time"`
+	ConflictID       string                  `json:"conflict_id"`
+	CurrentState     ConflictResolutionState `json:"current_state"`
+	ResolutionPath   []string                `json:"resolution_path"`
+	MatchedRules     []string                `json:"matched_rules"`
+	FailedRules      []string                `json:"failed_rules"`
+	AnalysisMetadata map[string]interface{}  `json:"analysis_metadata"`
+	Duration         time.Duration           `json:"duration"`
+	StartTime        time.Time               `json:"start_time"`
 }
 
 // IsTerminalState returns true if the current state is a terminal state

--- a/synckit/statemachine/machine.go
+++ b/synckit/statemachine/machine.go
@@ -2,13 +2,13 @@ package statemachine
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
-	"crypto/rand"
-	"encoding/hex"
 )
 
 // machine is the generic implementation of StateMachine interface.
@@ -16,21 +16,21 @@ type machine[T comparable] struct {
 	config     StateMachineConfig[T]
 	state      *AtomicState[T]
 	stateStart time.Time // When we entered current state
-	
+
 	// Thread-safe fields
-	mu          sync.RWMutex
-	observers   []StateObserver[T]
-	history     []StateTransition[T]
-	
+	mu        sync.RWMutex
+	observers []StateObserver[T]
+	history   []StateTransition[T]
+
 	// Metrics and validation
 	validator StateValidator[T]
 	metrics   StateMetrics[T]
-	
+
 	// Persistence support
-	persistence      StatePersistence[T]
-	machineID        string
+	persistence        StatePersistence[T]
+	machineID          string
 	persistenceEnabled bool
-	persistenceConfig PersistenceConfig
+	persistenceConfig  PersistenceConfig
 }
 
 // New creates a new state machine with the given configuration.
@@ -38,11 +38,11 @@ func New[T comparable](config StateMachineConfig[T]) (StateMachine[T], error) {
 	if config.TransitionRules == nil {
 		return nil, errors.New("transition rules cannot be nil")
 	}
-	
+
 	if config.MaxHistorySize <= 0 {
 		config.MaxHistorySize = 50
 	}
-	
+
 	m := &machine[T]{
 		config:     config,
 		state:      NewAtomicState(config.InitialState),
@@ -51,12 +51,12 @@ func New[T comparable](config StateMachineConfig[T]) (StateMachine[T], error) {
 		validator:  config.Validator,
 		metrics:    config.Metrics,
 	}
-	
+
 	// Record initial state
 	if m.metrics != nil && config.EnableMetrics {
 		m.metrics.RecordCurrentState(config.InitialState)
 	}
-	
+
 	return m, nil
 }
 
@@ -73,46 +73,46 @@ func (m *machine[T]) Transition(to T) error {
 // TransitionWithContext transitions with additional metadata.
 func (m *machine[T]) TransitionWithContext(to T, metadata map[string]interface{}) error {
 	from := m.state.Load()
-	
+
 	// Check if transition is valid
 	if !m.CanTransition(to) {
 		err := fmt.Errorf("invalid transition from %v to %v", from, to)
-		
+
 		// Notify observers of failed transition
 		m.notifyTransitionFailed(from, to, err, metadata)
-		
+
 		// Record error metric
 		if m.metrics != nil && m.config.EnableMetrics {
 			m.metrics.RecordTransitionError(from, to, err, metadata)
 		}
-		
+
 		return err
 	}
-	
+
 	// Custom validation
 	if m.validator != nil {
 		if err := m.validator.ValidateTransition(from, to); err != nil {
 			// Notify observers of failed transition
 			m.notifyTransitionFailed(from, to, err, metadata)
-			
+
 			// Record error metric
 			if m.metrics != nil && m.config.EnableMetrics {
 				m.metrics.RecordTransitionError(from, to, err, metadata)
 			}
-			
+
 			return fmt.Errorf("transition validation failed: %w", err)
 		}
 	}
-	
+
 	// Perform the transition
 	now := time.Now()
 	duration := now.Sub(m.stateStart)
 	transitionID := generateTransitionID()
-	
+
 	// Update state atomically
 	m.state.Store(to)
 	m.stateStart = now
-	
+
 	// Create transition record
 	transition := StateTransition[T]{
 		From:         from,
@@ -122,20 +122,20 @@ func (m *machine[T]) TransitionWithContext(to T, metadata map[string]interface{}
 		Metadata:     metadata,
 		TransitionID: transitionID,
 	}
-	
+
 	// Update history
 	m.addToHistory(transition)
-	
+
 	// Notify observers
 	m.notifyTransition(transition)
-	
+
 	// Record metrics
 	if m.metrics != nil && m.config.EnableMetrics {
 		m.metrics.RecordTransition(from, to, duration, metadata)
 		m.metrics.RecordCurrentState(to)
 		m.metrics.RecordStateDuration(from, duration)
 	}
-	
+
 	// Auto-save state if persistence is enabled
 	if m.persistenceEnabled && m.persistenceConfig.AutoSave && m.persistence != nil {
 		go func() {
@@ -145,7 +145,7 @@ func (m *machine[T]) TransitionWithContext(to T, metadata map[string]interface{}
 			}
 		}()
 	}
-	
+
 	return nil
 }
 
@@ -160,10 +160,10 @@ func (m *machine[T]) Subscribe(observer StateObserver[T]) {
 	if observer == nil {
 		return
 	}
-	
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	m.observers = append(m.observers, observer)
 }
 
@@ -172,10 +172,10 @@ func (m *machine[T]) Unsubscribe(observer StateObserver[T]) {
 	if observer == nil {
 		return
 	}
-	
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	for i, obs := range m.observers {
 		// Compare function pointers (this is a simplified approach)
 		// In practice, you might want to use unique IDs for observers
@@ -190,7 +190,7 @@ func (m *machine[T]) Unsubscribe(observer StateObserver[T]) {
 func (m *machine[T]) History() []StateTransition[T] {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	// Return a copy of the history to prevent external modification
 	history := make([]StateTransition[T], len(m.history))
 	copy(history, m.history)
@@ -211,36 +211,36 @@ func (m *machine[T]) ExportDOT() string {
 	defer m.mu.RUnlock()
 
 	var builder strings.Builder
-	
+
 	// DOT graph header
 	graphName := m.config.Name
 	if graphName == "" {
 		graphName = "StateMachine"
 	}
-	
+
 	builder.WriteString(fmt.Sprintf("digraph \"%s\" {\n", graphName))
 	builder.WriteString("\trankdir=LR;\n")
 	builder.WriteString("\tnode [shape=circle, style=filled];\n\n")
-	
+
 	// Current state highlighting
 	currentState := m.state.Load()
-	
+
 	// Collect all states from transition rules
 	statesMap := make(map[T]bool)
 	statesMap[m.config.InitialState] = true
 	statesMap[currentState] = true
-	
+
 	for from, targets := range m.config.TransitionRules {
 		statesMap[from] = true
 		for _, to := range targets {
 			statesMap[to] = true
 		}
 	}
-	
+
 	// Define state nodes with styling
 	for state := range statesMap {
 		stateStr := fmt.Sprintf("%v", state)
-		
+
 		// Determine node styling based on state type
 		var color, fillColor string
 		switch {
@@ -254,13 +254,13 @@ func (m *machine[T]) ExportDOT() string {
 			color = "black"
 			fillColor = "lightblue"
 		}
-		
-		builder.WriteString(fmt.Sprintf("\t\"%s\" [color=%s, fillcolor=%s, label=\"%s\"];\n", 
+
+		builder.WriteString(fmt.Sprintf("\t\"%s\" [color=%s, fillcolor=%s, label=\"%s\"];\n",
 			stateStr, color, fillColor, stateStr))
 	}
-	
+
 	builder.WriteString("\n")
-	
+
 	// Define transitions (edges)
 	for from, targets := range m.config.TransitionRules {
 		fromStr := fmt.Sprintf("%v", from)
@@ -269,7 +269,7 @@ func (m *machine[T]) ExportDOT() string {
 			builder.WriteString(fmt.Sprintf("\t\"%s\" -> \"%s\";\n", fromStr, toStr))
 		}
 	}
-	
+
 	// Add legend
 	builder.WriteString("\n\t// Legend\n")
 	builder.WriteString("\tsubgraph cluster_legend {\n")
@@ -280,9 +280,9 @@ func (m *machine[T]) ExportDOT() string {
 	builder.WriteString("\t\t\"Initial State\" [color=green, fillcolor=lightgreen, shape=circle];\n")
 	builder.WriteString("\t\t\"Other States\" [color=black, fillcolor=lightblue, shape=circle];\n")
 	builder.WriteString("\t}\n")
-	
+
 	builder.WriteString("}")
-	
+
 	return builder.String()
 }
 
@@ -290,16 +290,16 @@ func (m *machine[T]) ExportDOT() string {
 func (m *machine[T]) createSnapshot() *StateMachineSnapshot[T] {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	return &StateMachineSnapshot[T]{
-		MachineID:     m.machineID,
-		CurrentState:  m.state.Load(),
-		InitialState:  m.config.InitialState,
+		MachineID:      m.machineID,
+		CurrentState:   m.state.Load(),
+		InitialState:   m.config.InitialState,
 		StateEnteredAt: m.stateStart,
-		Config:        m.config,
-		History:       m.history,
-		SnapshotTime:  time.Now(),
-		Version:       1, // Basic versioning
+		Config:         m.config,
+		History:        m.history,
+		SnapshotTime:   time.Now(),
+		Version:        1, // Basic versioning
 	}
 }
 
@@ -326,7 +326,7 @@ func (m *machine[T]) EnablePersistence(persistence StatePersistence[T], machineI
 func (m *machine[T]) DisablePersistence() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	m.persistence = nil
 	m.machineID = ""
 	m.persistenceConfig = PersistenceConfig{}
@@ -352,9 +352,9 @@ func (m *machine[T]) restoreFromSnapshot(snapshot StateMachineSnapshot[T]) {
 func (m *machine[T]) addToHistory(transition StateTransition[T]) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	m.history = append(m.history, transition)
-	
+
 	// Maintain history size limit
 	if len(m.history) > m.config.MaxHistorySize {
 		m.history = m.history[1:]
@@ -367,7 +367,7 @@ func (m *machine[T]) notifyTransition(transition StateTransition[T]) {
 	observers := make([]StateObserver[T], len(m.observers))
 	copy(observers, m.observers)
 	m.mu.RUnlock()
-	
+
 	// Notify observers in separate goroutines to prevent blocking
 	for _, observer := range observers {
 		go func(obs StateObserver[T]) {
@@ -389,7 +389,7 @@ func (m *machine[T]) notifyTransitionFailed(from, to T, err error, metadata map[
 	observers := make([]StateObserver[T], len(m.observers))
 	copy(observers, m.observers)
 	m.mu.RUnlock()
-	
+
 	// Notify observers in separate goroutines to prevent blocking
 	for _, observer := range observers {
 		go func(obs StateObserver[T]) {
@@ -434,7 +434,7 @@ func (b *Builder[T]) Allow(from T, to ...T) *Builder[T] {
 	if b.config.TransitionRules == nil {
 		b.config.TransitionRules = make(TransitionRules[T])
 	}
-	
+
 	b.config.TransitionRules[from] = append(b.config.TransitionRules[from], to...)
 	return b
 }

--- a/synckit/statemachine/observability.go
+++ b/synckit/statemachine/observability.go
@@ -6,24 +6,24 @@ import (
 	"log/slog"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ObservabilityHooks integrates state machines with existing observability infrastructure.
 type ObservabilityHooks[T comparable] struct {
 	// MetricsCollector for recording state machine metrics
 	MetricsCollector StateMetricsCollector
-	
+
 	// Tracer for distributed tracing integration
 	Tracer StateTracer
-	
+
 	// HealthUpdater for health check integration
 	HealthUpdater StateHealthUpdater
-	
+
 	// Logger for structured logging
 	Logger *slog.Logger
-	
+
 	// ComponentName identifies the component for observability
 	ComponentName string
 }
@@ -33,16 +33,16 @@ type ObservabilityHooks[T comparable] struct {
 type StateMetricsCollector interface {
 	// RecordStateTransition records a successful state transition
 	RecordStateTransition(component, from, to string, duration time.Duration, metadata map[string]interface{})
-	
+
 	// RecordStateTransitionError records a failed state transition
 	RecordStateTransitionError(component, from, to, errorType string, metadata map[string]interface{})
-	
+
 	// RecordCurrentState updates the current state gauge
 	RecordCurrentState(component, state string)
-	
+
 	// RecordStateDuration records time spent in a state
 	RecordStateDuration(component, state string, duration time.Duration)
-	
+
 	// RecordStateTransitionLatency records how long a transition took
 	RecordStateTransitionLatency(component, from, to string, latency time.Duration)
 }
@@ -51,10 +51,10 @@ type StateMetricsCollector interface {
 type StateTracer interface {
 	// StartStateTransition starts a new span for a state transition
 	StartStateTransition(ctx context.Context, component, from, to string) (context.Context, trace.Span)
-	
+
 	// RecordTransitionSuccess records successful transition attributes
 	RecordTransitionSuccess(span trace.Span, component, from, to, transitionID string, duration time.Duration, metadata map[string]interface{})
-	
+
 	// RecordTransitionError records failed transition error
 	RecordTransitionError(span trace.Span, component, from, to string, err error, metadata map[string]interface{})
 }
@@ -63,7 +63,7 @@ type StateTracer interface {
 type StateHealthUpdater interface {
 	// UpdateComponentState updates the health check state for a component
 	UpdateComponentState(component, state string, metadata map[string]interface{})
-	
+
 	// RecordStateError records a state-related error for health monitoring
 	RecordStateError(component, state string, err error)
 }
@@ -78,10 +78,10 @@ func NewObservabilityHooks[T comparable](
 ) *ObservabilityHooks[T] {
 	return &ObservabilityHooks[T]{
 		MetricsCollector: metricsCollector,
-		Tracer:          tracer,
-		HealthUpdater:   healthUpdater,
-		Logger:          logger,
-		ComponentName:   componentName,
+		Tracer:           tracer,
+		HealthUpdater:    healthUpdater,
+		Logger:           logger,
+		ComponentName:    componentName,
 	}
 }
 
@@ -89,7 +89,7 @@ func NewObservabilityHooks[T comparable](
 func (h *ObservabilityHooks[T]) OnTransition(transition StateTransition[T]) {
 	fromStr := fmt.Sprintf("%v", transition.From)
 	toStr := fmt.Sprintf("%v", transition.To)
-	
+
 	// Record metrics
 	if h.MetricsCollector != nil {
 		h.MetricsCollector.RecordStateTransition(
@@ -98,12 +98,12 @@ func (h *ObservabilityHooks[T]) OnTransition(transition StateTransition[T]) {
 		h.MetricsCollector.RecordCurrentState(h.ComponentName, toStr)
 		h.MetricsCollector.RecordStateDuration(h.ComponentName, fromStr, transition.Duration)
 	}
-	
+
 	// Update health status
 	if h.HealthUpdater != nil {
 		h.HealthUpdater.UpdateComponentState(h.ComponentName, toStr, transition.Metadata)
 	}
-	
+
 	// Structured logging
 	if h.Logger != nil {
 		h.Logger.Info("State transition completed",
@@ -121,23 +121,23 @@ func (h *ObservabilityHooks[T]) OnTransitionFailed(from, to T, err error, metada
 	fromStr := fmt.Sprintf("%v", from)
 	toStr := fmt.Sprintf("%v", to)
 	errorType := "transition_failed"
-	
+
 	if err != nil {
 		errorType = err.Error()
 	}
-	
+
 	// Record error metrics
 	if h.MetricsCollector != nil {
 		h.MetricsCollector.RecordStateTransitionError(
 			h.ComponentName, fromStr, toStr, errorType, metadata,
 		)
 	}
-	
+
 	// Record health error
 	if h.HealthUpdater != nil {
 		h.HealthUpdater.RecordStateError(h.ComponentName, fromStr, err)
 	}
-	
+
 	// Error logging
 	if h.Logger != nil {
 		h.Logger.Error("State transition failed",
@@ -235,7 +235,7 @@ func (a *SyncKitTracerAdapter) RecordTransitionSuccess(span trace.Span, componen
 		attribute.String("state.transition_id", transitionID),
 		attribute.Int64("state.duration_ms", duration.Milliseconds()),
 	)
-	
+
 	// Add metadata as span attributes
 	if metadata != nil {
 		for key, value := range metadata {
@@ -248,7 +248,7 @@ func (a *SyncKitTracerAdapter) RecordTransitionSuccess(span trace.Span, componen
 func (a *SyncKitTracerAdapter) RecordTransitionError(span trace.Span, component, from, to string, err error, metadata map[string]interface{}) {
 	description := fmt.Sprintf("State transition failed: %s -> %s", from, to)
 	a.tracer.RecordError(span, err, description)
-	
+
 	// Add error-specific attributes
 	span.SetAttributes(
 		attribute.String("state.component", component),
@@ -262,10 +262,10 @@ func (a *SyncKitTracerAdapter) RecordTransitionError(span trace.Span, component,
 type StateHealthStatus string
 
 const (
-	StateHealthHealthy    StateHealthStatus = "healthy"
-	StateHealthDegraded   StateHealthStatus = "degraded"
-	StateHealthUnhealthy  StateHealthStatus = "unhealthy"
-	StateHealthCritical   StateHealthStatus = "critical"
+	StateHealthHealthy   StateHealthStatus = "healthy"
+	StateHealthDegraded  StateHealthStatus = "degraded"
+	StateHealthUnhealthy StateHealthStatus = "unhealthy"
+	StateHealthCritical  StateHealthStatus = "critical"
 )
 
 // DefaultStateHealthUpdater provides a simple health updater implementation.
@@ -275,7 +275,7 @@ type DefaultStateHealthUpdater struct {
 		UpdateStatus(component string, status string, metadata map[string]interface{})
 		RecordError(component string, err error)
 	}
-	
+
 	// stateHealthMap maps states to health statuses
 	stateHealthMap map[string]StateHealthStatus
 }
@@ -291,21 +291,21 @@ func NewDefaultStateHealthUpdater(
 		healthChecker: healthChecker,
 		stateHealthMap: map[string]StateHealthStatus{
 			// Sync states
-			"idle":                 StateHealthHealthy,
-			"initializing":         StateHealthHealthy,
-			"pushing":              StateHealthHealthy,
-			"pulling":              StateHealthHealthy,
-			"resolving_conflicts":  StateHealthDegraded,
-			"completed":            StateHealthHealthy,
-			"failed":               StateHealthCritical,
-			"cancelled":            StateHealthDegraded,
-			
+			"idle":                StateHealthHealthy,
+			"initializing":        StateHealthHealthy,
+			"pushing":             StateHealthHealthy,
+			"pulling":             StateHealthHealthy,
+			"resolving_conflicts": StateHealthDegraded,
+			"completed":           StateHealthHealthy,
+			"failed":              StateHealthCritical,
+			"cancelled":           StateHealthDegraded,
+
 			// Transport states (for future use)
-			"connected":            StateHealthHealthy,
-			"connecting":           StateHealthDegraded,
-			"disconnected":         StateHealthUnhealthy,
-			"reconnecting":         StateHealthDegraded,
-			"transport_failed":     StateHealthCritical,
+			"connected":        StateHealthHealthy,
+			"connecting":       StateHealthDegraded,
+			"disconnected":     StateHealthUnhealthy,
+			"reconnecting":     StateHealthDegraded,
+			"transport_failed": StateHealthCritical,
 		},
 	}
 }
@@ -315,26 +315,26 @@ func (h *DefaultStateHealthUpdater) UpdateComponentState(component, state string
 	if h.healthChecker == nil {
 		return
 	}
-	
+
 	// Map state to health status
 	healthStatus := StateHealthHealthy // default
 	if status, exists := h.stateHealthMap[state]; exists {
 		healthStatus = status
 	}
-	
+
 	// Update health status
 	healthMetadata := map[string]interface{}{
-		"state": state,
+		"state":     state,
 		"timestamp": time.Now().Format(time.RFC3339),
 	}
-	
+
 	// Include original metadata
 	if metadata != nil {
 		for key, value := range metadata {
 			healthMetadata[key] = value
 		}
 	}
-	
+
 	h.healthChecker.UpdateStatus(component, string(healthStatus), healthMetadata)
 }
 
@@ -343,7 +343,7 @@ func (h *DefaultStateHealthUpdater) RecordStateError(component, state string, er
 	if h.healthChecker == nil {
 		return
 	}
-	
+
 	h.healthChecker.RecordError(component, err)
 }
 
@@ -364,15 +364,15 @@ func CreateObservableStateMachine[T comparable](
 		logger,
 		componentName,
 	)
-	
+
 	// Create the state machine
 	stateMachine, err := New(config)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Subscribe to state changes
 	stateMachine.Subscribe(hooks)
-	
+
 	return stateMachine, nil
 }

--- a/synckit/statemachine/persistence.go
+++ b/synckit/statemachine/persistence.go
@@ -12,13 +12,13 @@ import (
 type StatePersistence[T comparable] interface {
 	// SaveState persists the current state machine state
 	SaveState(ctx context.Context, machineID string, state StateMachineSnapshot[T]) error
-	
+
 	// LoadState retrieves the persisted state for a state machine
 	LoadState(ctx context.Context, machineID string) (*StateMachineSnapshot[T], error)
-	
+
 	// DeleteState removes persisted state (cleanup)
 	DeleteState(ctx context.Context, machineID string) error
-	
+
 	// ListMachines returns all persisted state machine IDs
 	ListMachines(ctx context.Context) ([]string, error)
 }
@@ -27,23 +27,22 @@ type StatePersistence[T comparable] interface {
 // that can be persisted and restored for resilience across restarts.
 type StateMachineSnapshot[T comparable] struct {
 	// Core state information
-	MachineID     string    `json:"machine_id"`
-	CurrentState  T         `json:"current_state"`
-	InitialState  T         `json:"initial_state"`
+	MachineID      string    `json:"machine_id"`
+	CurrentState   T         `json:"current_state"`
+	InitialState   T         `json:"initial_state"`
 	StateEnteredAt time.Time `json:"state_entered_at"`
-	
+
 	// Configuration snapshot
 	Config StateMachineConfig[T] `json:"config"`
-	
+
 	// History and metadata
-	History     []StateTransition[T] `json:"history"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
-	
+	History  []StateTransition[T]   `json:"history"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+
 	// Persistence metadata
 	SnapshotTime time.Time `json:"snapshot_time"`
 	Version      int       `json:"version"`
 }
-
 
 // MemoryStatePersistence provides an in-memory implementation of StatePersistence
 // for testing and development purposes.
@@ -108,13 +107,13 @@ func (jp *JSONStatePersistence[T]) SaveState(ctx context.Context, machineID stri
 	if err != nil {
 		return err
 	}
-	
+
 	// In a real implementation, you would:
 	// 1. Write to a temporary file first
 	// 2. Atomically rename to final location
 	// 3. Handle file locking/concurrency
 	// 4. Implement proper error handling
-	
+
 	// For now, return nil to indicate the interface implementation
 	_ = data
 	return nil
@@ -127,7 +126,7 @@ func (jp *JSONStatePersistence[T]) LoadState(ctx context.Context, machineID stri
 	// 2. Unmarshal into StateMachineSnapshot
 	// 3. Validate the snapshot
 	// 4. Handle file not found scenarios
-	
+
 	// For now, return nil to indicate no state found
 	return nil, nil
 }
@@ -148,16 +147,16 @@ func (jp *JSONStatePersistence[T]) ListMachines(ctx context.Context) ([]string, 
 type PersistenceConfig struct {
 	// AutoSave enables automatic state saving after each transition
 	AutoSave bool
-	
+
 	// SaveInterval for periodic state saves (if AutoSave is false)
 	SaveInterval time.Duration
-	
+
 	// RetentionPeriod for automatic cleanup of old state snapshots
 	RetentionPeriod time.Duration
-	
+
 	// MaxSnapshots to keep for each state machine
 	MaxSnapshots int
-	
+
 	// CompressSnapshots enables compression for storage efficiency
 	CompressSnapshots bool
 }

--- a/synckit/statemachine/timeout.go
+++ b/synckit/statemachine/timeout.go
@@ -12,14 +12,14 @@ import (
 type TimeoutHandler[T comparable] struct {
 	stateMachine StateMachine[T]
 	timeouts     map[T]time.Duration
-	
+
 	// Current timeout tracking
 	currentTimeout context.CancelFunc
 	mu             sync.RWMutex
-	
+
 	// Configuration
 	config TimeoutConfig
-	
+
 	// Callbacks
 	onTimeout func(from T, duration time.Duration)
 }
@@ -28,19 +28,19 @@ type TimeoutHandler[T comparable] struct {
 type TimeoutConfig struct {
 	// DefaultTimeout is used when no specific timeout is configured for a state
 	DefaultTimeout time.Duration
-	
+
 	// EnableTimeouts globally enables/disables timeout handling
 	EnableTimeouts bool
-	
+
 	// TimeoutAction specifies what to do when a timeout occurs
 	TimeoutAction TimeoutAction
-	
+
 	// TargetState is the state to transition to on timeout (if TimeoutAction is TransitionTo)
 	TargetState interface{}
-	
+
 	// MaxRetries for timeout recovery attempts
 	MaxRetries int
-	
+
 	// RetryDelay between timeout recovery attempts
 	RetryDelay time.Duration
 }
@@ -51,16 +51,16 @@ type TimeoutAction int
 const (
 	// TimeoutActionTransition automatically transitions to a target state
 	TimeoutActionTransition TimeoutAction = iota
-	
+
 	// TimeoutActionFail marks the state machine as failed
 	TimeoutActionFail
-	
+
 	// TimeoutActionCallback calls a custom callback function
 	TimeoutActionCallback
-	
+
 	// TimeoutActionReset resets the state machine to initial state
 	TimeoutActionReset
-	
+
 	// TimeoutActionIgnore logs the timeout but takes no action
 	TimeoutActionIgnore
 )
@@ -112,28 +112,28 @@ func (th *TimeoutHandler[T]) StartTimeout() {
 	if !th.config.EnableTimeouts {
 		return
 	}
-	
+
 	th.mu.Lock()
 	defer th.mu.Unlock()
-	
+
 	// Cancel any existing timeout
 	if th.currentTimeout != nil {
 		th.currentTimeout()
 		th.currentTimeout = nil
 	}
-	
+
 	currentState := th.stateMachine.Current()
 	timeout := th.getTimeoutForState(currentState)
-	
+
 	if timeout <= 0 {
 		// No timeout configured for this state
 		return
 	}
-	
+
 	// Create a cancellable context for this timeout
 	ctx, cancel := context.WithCancel(context.Background())
 	th.currentTimeout = cancel
-	
+
 	// Start timeout monitoring in a goroutine
 	go th.monitorTimeout(ctx, currentState, timeout)
 }
@@ -142,7 +142,7 @@ func (th *TimeoutHandler[T]) StartTimeout() {
 func (th *TimeoutHandler[T]) StopTimeout() {
 	th.mu.Lock()
 	defer th.mu.Unlock()
-	
+
 	if th.currentTimeout != nil {
 		th.currentTimeout()
 		th.currentTimeout = nil
@@ -162,12 +162,12 @@ func (th *TimeoutHandler[T]) getTimeoutForState(state T) time.Duration {
 func (th *TimeoutHandler[T]) monitorTimeout(ctx context.Context, state T, timeout time.Duration) {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
-	
+
 	select {
 	case <-ctx.Done():
 		// Timeout was cancelled (state changed or timeout handler stopped)
 		return
-		
+
 	case <-timer.C:
 		// Timeout occurred
 		th.handleTimeout(state, timeout)
@@ -180,21 +180,21 @@ func (th *TimeoutHandler[T]) handleTimeout(state T, duration time.Duration) {
 	if th.onTimeout != nil {
 		th.onTimeout(state, duration)
 	}
-	
+
 	// Take the configured action
 	switch th.config.TimeoutAction {
 	case TimeoutActionTransition:
 		th.handleTimeoutTransition(state)
-		
+
 	case TimeoutActionFail:
 		th.handleTimeoutFail(state)
-		
+
 	case TimeoutActionReset:
 		th.handleTimeoutReset(state)
-		
+
 	case TimeoutActionCallback:
 		// Callback was already called above
-		
+
 	case TimeoutActionIgnore:
 		// Do nothing except log (callback handles logging)
 	}
@@ -205,7 +205,7 @@ func (th *TimeoutHandler[T]) handleTimeoutTransition(state T) {
 	if th.config.TargetState == nil {
 		return
 	}
-	
+
 	if targetState, ok := th.config.TargetState.(T); ok {
 		th.stateMachine.TransitionWithContext(targetState, map[string]interface{}{
 			"timeout":      true,
@@ -219,10 +219,10 @@ func (th *TimeoutHandler[T]) handleTimeoutTransition(state T) {
 func (th *TimeoutHandler[T]) handleTimeoutFail(state T) {
 	// For this to work, the state machine must have a "failed" state defined
 	// This is a generic approach - specific implementations might need different logic
-	
+
 	// Try common failure state names
 	failureStates := []interface{}{"failed", "error", "timeout", "stuck"}
-	
+
 	for _, failState := range failureStates {
 		if typedState, ok := failState.(T); ok {
 			if th.stateMachine.CanTransition(typedState) {
@@ -272,66 +272,72 @@ func (to *TimeoutObserver[T]) OnTransitionFailed(from, toState T, err error, met
 	// Keep existing timeout on transition failure
 }
 
-// TimeoutMetrics tracks timeout-related metrics for monitoring and alerting.
+// TimeoutMetrics is a snapshot of timeout-related metrics for monitoring and alerting.
 type TimeoutMetrics struct {
-	TotalTimeouts      int64         `json:"total_timeouts"`
+	TotalTimeouts      int64            `json:"total_timeouts"`
 	TimeoutsByState    map[string]int64 `json:"timeouts_by_state"`
-	AverageTimeoutTime time.Duration `json:"average_timeout_time"`
-	MaxTimeoutTime     time.Duration `json:"max_timeout_time"`
-	LastTimeout        time.Time     `json:"last_timeout"`
-	
-	mu sync.RWMutex
+	AverageTimeoutTime time.Duration    `json:"average_timeout_time"`
+	MaxTimeoutTime     time.Duration    `json:"max_timeout_time"`
+	LastTimeout        time.Time        `json:"last_timeout"`
+}
+
+// TimeoutMetricsTracker tracks metrics with internal synchronization.
+type TimeoutMetricsTracker struct {
+	mu   sync.RWMutex
+	data TimeoutMetrics
 }
 
 // NewTimeoutMetrics creates a new timeout metrics tracker.
-func NewTimeoutMetrics() *TimeoutMetrics {
-	return &TimeoutMetrics{
-		TimeoutsByState: make(map[string]int64),
+func NewTimeoutMetrics() *TimeoutMetricsTracker {
+	return &TimeoutMetricsTracker{
+		data: TimeoutMetrics{
+			TimeoutsByState: make(map[string]int64),
+		},
 	}
 }
 
 // RecordTimeout records a timeout occurrence for metrics.
-func (tm *TimeoutMetrics) RecordTimeout(state string, duration time.Duration) {
+func (tm *TimeoutMetricsTracker) RecordTimeout(state string, duration time.Duration) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
-	
-	tm.TotalTimeouts++
-	tm.TimeoutsByState[state]++
-	tm.LastTimeout = time.Now()
-	
+
+	tm.data.TotalTimeouts++
+	tm.data.TimeoutsByState[state]++
+	tm.data.LastTimeout = time.Now()
+
 	// Update duration metrics
-	if duration > tm.MaxTimeoutTime {
-		tm.MaxTimeoutTime = duration
+	if duration > tm.data.MaxTimeoutTime {
+		tm.data.MaxTimeoutTime = duration
 	}
-	
+
 	// Calculate running average (simplified)
-	if tm.TotalTimeouts == 1 {
-		tm.AverageTimeoutTime = duration
+	if tm.data.TotalTimeouts == 1 {
+		tm.data.AverageTimeoutTime = duration
 	} else {
 		// Running average: new_avg = old_avg + (new_value - old_avg) / count
-		tm.AverageTimeoutTime = tm.AverageTimeoutTime + 
-			(duration-tm.AverageTimeoutTime)/time.Duration(tm.TotalTimeouts)
+		tm.data.AverageTimeoutTime = tm.data.AverageTimeoutTime +
+			(duration-tm.data.AverageTimeoutTime)/time.Duration(tm.data.TotalTimeouts)
 	}
 }
 
 // GetMetrics returns a copy of the current metrics.
-func (tm *TimeoutMetrics) GetMetrics() TimeoutMetrics {
+func (tm *TimeoutMetricsTracker) GetMetrics() TimeoutMetrics {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
-	
+
 	// Create a copy to avoid race conditions
 	copyMetrics := TimeoutMetrics{
-		TotalTimeouts:      tm.TotalTimeouts,
+		TotalTimeouts:      tm.data.TotalTimeouts,
 		TimeoutsByState:    make(map[string]int64),
-		AverageTimeoutTime: tm.AverageTimeoutTime,
-		MaxTimeoutTime:     tm.MaxTimeoutTime,
-		LastTimeout:        tm.LastTimeout,
+		AverageTimeoutTime: tm.data.AverageTimeoutTime,
+		MaxTimeoutTime:     tm.data.MaxTimeoutTime,
+		LastTimeout:        tm.data.LastTimeout,
 	}
-	
-	for state, count := range tm.TimeoutsByState {
+
+	for state, count := range tm.data.TimeoutsByState {
 		copyMetrics.TimeoutsByState[state] = count
 	}
-	
+
 	return copyMetrics
 }
 

--- a/synckit/statemachine/transport_manager.go
+++ b/synckit/statemachine/transport_manager.go
@@ -13,16 +13,16 @@ import (
 type Transport interface {
 	// Push sends events to the remote endpoint
 	Push(ctx context.Context, events []interface{}) error
-	
+
 	// Pull retrieves events from the remote endpoint
 	Pull(ctx context.Context, since interface{}) ([]interface{}, error)
-	
+
 	// GetLatestVersion efficiently retrieves the latest version from remote
 	GetLatestVersion(ctx context.Context) (interface{}, error)
-	
+
 	// Subscribe listens for real-time updates (optional)
 	Subscribe(ctx context.Context, handler func([]interface{}) error) error
-	
+
 	// Close closes the transport connection
 	Close() error
 }
@@ -31,22 +31,22 @@ type Transport interface {
 type StatefulTransport interface {
 	// GetConnectionState returns the current connection state
 	GetConnectionState() TransportState
-	
+
 	// SubscribeToStateChanges allows listening to transport state changes
 	SubscribeToStateChanges(handler TransportStateHandler) error
-	
+
 	// Connect attempts to establish a connection with state tracking
 	Connect(ctx context.Context) error
-	
+
 	// Disconnect gracefully closes the connection with state tracking
 	Disconnect(ctx context.Context) error
-	
+
 	// IsHealthy returns true if the transport is in a healthy state for operations
 	IsHealthy() bool
-	
+
 	// GetLastError returns the last error that occurred, if any
 	GetLastError() error
-	
+
 	// GetConnectionMetadata returns metadata about the current connection
 	GetConnectionMetadata() map[string]interface{}
 }
@@ -56,21 +56,21 @@ type TransportStateHandler func(transition StateTransition[TransportState])
 
 // TransportStateManager manages the state of transport connections with observability integration
 type TransportStateManager struct {
-	stateMachine     StateMachine[TransportState]
-	logger           *slog.Logger
-	mu               sync.RWMutex
-	
+	stateMachine StateMachine[TransportState]
+	logger       *slog.Logger
+	mu           sync.RWMutex
+
 	// Connection tracking
-	endpoint         string
-	lastError        error
-	connectionTime   time.Time
-	totalAttempts    int
-	
+	endpoint       string
+	lastError      error
+	connectionTime time.Time
+	totalAttempts  int
+
 	// Observability hooks
 	observabilityHooks *ObservabilityHooks[TransportState]
-	
+
 	// External state change handlers
-	stateHandlers    []TransportStateHandler
+	stateHandlers []TransportStateHandler
 }
 
 // TransportStateManagerConfig configures the transport state manager
@@ -90,24 +90,24 @@ func NewTransportStateManager(config TransportStateManagerConfig) (*TransportSta
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transport state machine: %w", err)
 	}
-	
+
 	logger := config.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
-	
+
 	componentName := config.ComponentName
 	if componentName == "" {
 		componentName = "transport_manager"
 	}
-	
+
 	manager := &TransportStateManager{
-		stateMachine:   stateMachine,
+		stateMachine:  stateMachine,
 		logger:        logger,
 		endpoint:      config.Endpoint,
 		stateHandlers: make([]TransportStateHandler, 0),
 	}
-	
+
 	// Setup observability integration if components are provided
 	if config.MetricsCollector != nil || config.Tracer != nil || config.HealthUpdater != nil {
 		hooks := NewObservabilityHooks[TransportState](
@@ -117,14 +117,14 @@ func NewTransportStateManager(config TransportStateManagerConfig) (*TransportSta
 			logger,
 			componentName,
 		)
-		
+
 		manager.observabilityHooks = hooks
 		stateMachine.Subscribe(hooks)
 	}
-	
+
 	// Subscribe to state changes for internal tracking
 	stateMachine.Subscribe(manager)
-	
+
 	return manager, nil
 }
 
@@ -132,28 +132,28 @@ func NewTransportStateManager(config TransportStateManagerConfig) (*TransportSta
 func (tsm *TransportStateManager) OnTransition(transition StateTransition[TransportState]) {
 	tsm.mu.Lock()
 	defer tsm.mu.Unlock()
-	
+
 	// Update internal tracking based on transition
 	switch transition.To {
 	case TransportConnecting:
 		tsm.totalAttempts++
 		tsm.lastError = nil
-		
+
 	case TransportConnected:
 		tsm.connectionTime = transition.Timestamp
 		tsm.lastError = nil
-		
+
 	case TransportFailed:
 		if errorMsg, ok := transition.Metadata["error"]; ok {
 			if errorStr, ok := errorMsg.(string); ok {
 				tsm.lastError = fmt.Errorf("%s", errorStr)
 			}
 		}
-		
+
 	case TransportDisconnected:
 		tsm.lastError = nil
 	}
-	
+
 	// Notify external handlers
 	for _, handler := range tsm.stateHandlers {
 		// Run handlers in goroutines to avoid blocking
@@ -169,7 +169,7 @@ func (tsm *TransportStateManager) OnTransition(transition StateTransition[Transp
 			h(transition)
 		}(handler)
 	}
-	
+
 	tsm.logger.Debug("Transport state transition",
 		"from", transition.From.String(),
 		"to", transition.To.String(),
@@ -196,10 +196,10 @@ func (tsm *TransportStateManager) SubscribeToStateChanges(handler TransportState
 	if handler == nil {
 		return fmt.Errorf("handler cannot be nil")
 	}
-	
+
 	tsm.mu.Lock()
 	defer tsm.mu.Unlock()
-	
+
 	tsm.stateHandlers = append(tsm.stateHandlers, handler)
 	return nil
 }
@@ -210,7 +210,7 @@ func (tsm *TransportStateManager) TransitionToConnecting(timeout time.Duration) 
 	if !currentState.CanConnect() {
 		return fmt.Errorf("cannot connect from state: %s", currentState.String())
 	}
-	
+
 	metadata := TransportMeta.ConnectingMetadata(tsm.endpoint, timeout)
 	return tsm.stateMachine.TransitionWithContext(TransportConnecting, metadata)
 }
@@ -227,7 +227,7 @@ func (tsm *TransportStateManager) TransitionToReconnecting(reason string, attemp
 	if !currentState.CanReconnect() {
 		return fmt.Errorf("cannot reconnect from state: %s", currentState.String())
 	}
-	
+
 	metadata := TransportMeta.ReconnectingMetadata(reason, attempt, nextRetry)
 	return tsm.stateMachine.TransitionWithContext(TransportReconnecting, metadata)
 }
@@ -277,26 +277,26 @@ func (tsm *TransportStateManager) GetLastError() error {
 func (tsm *TransportStateManager) GetConnectionMetadata() map[string]interface{} {
 	tsm.mu.RLock()
 	defer tsm.mu.RUnlock()
-	
+
 	state := tsm.stateMachine.Current()
 	metadata := map[string]interface{}{
-		"current_state":   state.String(),
-		"endpoint":       tsm.endpoint,
-		"total_attempts": tsm.totalAttempts,
-		"is_connected":   state.IsConnected(),
-		"can_send_data":  state.CanSendData(),
+		"current_state":    state.String(),
+		"endpoint":         tsm.endpoint,
+		"total_attempts":   tsm.totalAttempts,
+		"is_connected":     state.IsConnected(),
+		"can_send_data":    state.CanSendData(),
 		"can_receive_data": state.CanReceiveData(),
 	}
-	
+
 	if !tsm.connectionTime.IsZero() {
 		metadata["connected_at"] = tsm.connectionTime.Format(time.RFC3339)
 		metadata["connection_duration"] = time.Since(tsm.connectionTime).String()
 	}
-	
+
 	if tsm.lastError != nil {
 		metadata["last_error"] = tsm.lastError.Error()
 	}
-	
+
 	return metadata
 }
 
@@ -314,19 +314,19 @@ func (tsm *TransportStateManager) Close() error {
 			tsm.logger.Error("Failed to transition to shutting down state during close", "error", err)
 		}
 	}
-	
+
 	tsm.mu.Lock()
 	defer tsm.mu.Unlock()
-	
+
 	// Clear handlers
 	tsm.stateHandlers = nil
-	
+
 	return nil
 }
 
 // StatefulTransportWrapper wraps an existing transport with state management capabilities
 type StatefulTransportWrapper struct {
-	transport Transport
+	transport    Transport
 	stateManager *TransportStateManager
 }
 
@@ -339,7 +339,7 @@ func NewStatefulTransportWrapper(transport Transport, config TransportStateManag
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transport state manager: %w", err)
 	}
-	
+
 	return &StatefulTransportWrapper{
 		transport:    transport,
 		stateManager: stateManager,
@@ -374,20 +374,20 @@ func (stw *StatefulTransportWrapper) GetConnectionMetadata() map[string]interfac
 // Close closes both the state manager and the underlying transport
 func (stw *StatefulTransportWrapper) Close() error {
 	var errs []error
-	
+
 	// Close state manager first
 	if err := stw.stateManager.Close(); err != nil {
 		errs = append(errs, fmt.Errorf("state manager close error: %w", err))
 	}
-	
+
 	// Close underlying transport
 	if err := stw.transport.Close(); err != nil {
 		errs = append(errs, fmt.Errorf("transport close error: %w", err))
 	}
-	
+
 	if len(errs) > 0 {
 		return fmt.Errorf("multiple close errors: %v", errs)
 	}
-	
+
 	return nil
 }

--- a/synckit/statemachine/transport_states.go
+++ b/synckit/statemachine/transport_states.go
@@ -11,19 +11,19 @@ type TransportState int
 const (
 	// TransportDisconnected indicates the transport is not connected
 	TransportDisconnected TransportState = iota
-	
+
 	// TransportConnecting indicates a connection attempt is in progress
 	TransportConnecting
-	
+
 	// TransportConnected indicates the transport is connected and active
 	TransportConnected
-	
+
 	// TransportReconnecting indicates the transport is attempting to reconnect after a failure
 	TransportReconnecting
-	
+
 	// TransportFailed indicates the transport has failed and cannot connect
 	TransportFailed
-	
+
 	// TransportShuttingDown indicates the transport is being shut down gracefully
 	TransportShuttingDown
 )
@@ -94,56 +94,56 @@ func NewTransportStateMachine() (StateMachine[TransportState], error) {
 	transitionRules := TransitionRules[TransportState]{
 		// From Disconnected
 		TransportDisconnected: {
-			TransportConnecting,    // Start connecting
+			TransportConnecting,   // Start connecting
 			TransportShuttingDown, // Direct shutdown without connecting
 		},
-		
+
 		// From Connecting
 		TransportConnecting: {
-			TransportConnected,     // Connection successful
-			TransportFailed,        // Connection failed
-			TransportDisconnected,  // Connection cancelled
-			TransportShuttingDown,  // Shutdown during connection
+			TransportConnected,    // Connection successful
+			TransportFailed,       // Connection failed
+			TransportDisconnected, // Connection cancelled
+			TransportShuttingDown, // Shutdown during connection
 		},
-		
+
 		// From Connected
 		TransportConnected: {
-			TransportReconnecting,  // Connection lost, attempting to reconnect
-			TransportDisconnected,  // Clean disconnection
-			TransportFailed,        // Connection failed permanently
-			TransportShuttingDown,  // Graceful shutdown
+			TransportReconnecting, // Connection lost, attempting to reconnect
+			TransportDisconnected, // Clean disconnection
+			TransportFailed,       // Connection failed permanently
+			TransportShuttingDown, // Graceful shutdown
 		},
-		
+
 		// From Reconnecting
 		TransportReconnecting: {
-			TransportConnected,     // Reconnection successful
-			TransportFailed,        // Reconnection failed permanently
-			TransportDisconnected,  // Gave up reconnecting
-			TransportShuttingDown,  // Shutdown during reconnection
+			TransportConnected,    // Reconnection successful
+			TransportFailed,       // Reconnection failed permanently
+			TransportDisconnected, // Gave up reconnecting
+			TransportShuttingDown, // Shutdown during reconnection
 		},
-		
+
 		// From Failed
 		TransportFailed: {
-			TransportConnecting,    // Manual retry attempt
-			TransportShuttingDown,  // Shutdown after failure
+			TransportConnecting,   // Manual retry attempt
+			TransportShuttingDown, // Shutdown after failure
 		},
-		
+
 		// From ShuttingDown - terminal state, no transitions allowed
 		TransportShuttingDown: {},
 	}
-	
+
 	// Create validator for additional validation logic
 	validator := &transportStateValidator{}
-	
+
 	config := StateMachineConfig[TransportState]{
 		InitialState:    TransportDisconnected,
 		TransitionRules: transitionRules,
 		Validator:       validator,
 		MaxHistorySize:  50,
 		EnableMetrics:   true,
-		Name:           "transport_connection",
+		Name:            "transport_connection",
 	}
-	
+
 	return New(config)
 }
 
@@ -156,7 +156,7 @@ func (v *transportStateValidator) ValidateTransition(from, to TransportState) er
 	case from == TransportShuttingDown:
 		return fmt.Errorf("cannot transition from shutting down state")
 	}
-	
+
 	return nil
 }
 
@@ -166,10 +166,10 @@ type TransportStateMetadata struct{}
 // ConnectingMetadata creates metadata for connection attempts
 func (TransportStateMetadata) ConnectingMetadata(endpoint string, timeout time.Duration) map[string]interface{} {
 	return map[string]interface{}{
-		"endpoint":     endpoint,
-		"timeout":      timeout,
-		"started_at":   time.Now().Format(time.RFC3339),
-		"operation":    "connecting",
+		"endpoint":   endpoint,
+		"timeout":    timeout,
+		"started_at": time.Now().Format(time.RFC3339),
+		"operation":  "connecting",
 	}
 }
 
@@ -187,10 +187,10 @@ func (TransportStateMetadata) ConnectedMetadata(endpoint string, connectionTime 
 func (TransportStateMetadata) ReconnectingMetadata(reason string, attempt int, nextRetry time.Duration) map[string]interface{} {
 	return map[string]interface{}{
 		"disconnect_reason": reason,
-		"attempt":          attempt,
-		"next_retry":       nextRetry,
-		"started_at":       time.Now().Format(time.RFC3339),
-		"operation":        "reconnecting",
+		"attempt":           attempt,
+		"next_retry":        nextRetry,
+		"started_at":        time.Now().Format(time.RFC3339),
+		"operation":         "reconnecting",
 	}
 }
 
@@ -209,9 +209,9 @@ func (TransportStateMetadata) FailedMetadata(err error, attempts int, duration t
 func (TransportStateMetadata) DisconnectedMetadata(reason string, graceful bool) map[string]interface{} {
 	return map[string]interface{}{
 		"disconnect_reason": reason,
-		"graceful":         graceful,
-		"disconnected_at":  time.Now().Format(time.RFC3339),
-		"operation":        "disconnected",
+		"graceful":          graceful,
+		"disconnected_at":   time.Now().Format(time.RFC3339),
+		"operation":         "disconnected",
 	}
 }
 

--- a/synckit/statemachine/types.go
+++ b/synckit/statemachine/types.go
@@ -12,23 +12,23 @@ import (
 type StateMachine[T comparable] interface {
 	// Current returns the current state
 	Current() T
-	
+
 	// Transition attempts to transition to the new state
 	// Returns error if transition is invalid
 	Transition(to T) error
-	
+
 	// TransitionWithContext transitions with additional metadata
 	TransitionWithContext(to T, metadata map[string]interface{}) error
-	
+
 	// CanTransition checks if a transition from current state to target state is valid
 	CanTransition(to T) bool
-	
+
 	// Subscribe adds a state change observer
 	Subscribe(observer StateObserver[T])
-	
+
 	// Unsubscribe removes a state change observer
 	Unsubscribe(observer StateObserver[T])
-	
+
 	// History returns recent state transition history.
 	History() []StateTransition[T]
 
@@ -47,7 +47,7 @@ type StateMachine[T comparable] interface {
 type StateObserver[T comparable] interface {
 	// OnTransition is called when a state transition succeeds
 	OnTransition(transition StateTransition[T])
-	
+
 	// OnTransitionFailed is called when a state transition fails
 	OnTransitionFailed(from, to T, err error, metadata map[string]interface{})
 }
@@ -56,19 +56,19 @@ type StateObserver[T comparable] interface {
 type StateTransition[T comparable] struct {
 	// From is the previous state
 	From T
-	
+
 	// To is the new state
 	To T
-	
+
 	// Timestamp when the transition occurred
 	Timestamp time.Time
-	
+
 	// Duration spent in the previous state (if available)
 	Duration time.Duration
-	
+
 	// Metadata associated with the transition
 	Metadata map[string]interface{}
-	
+
 	// TransitionID for tracking and correlation
 	TransitionID string
 }
@@ -88,7 +88,7 @@ func (tr TransitionRules[T]) Contains(from, to T) bool {
 	if !exists {
 		return false
 	}
-	
+
 	for _, allowed := range allowedStates {
 		if allowed == to {
 			return true
@@ -101,13 +101,13 @@ func (tr TransitionRules[T]) Contains(from, to T) bool {
 type StateMetrics[T comparable] interface {
 	// RecordTransition records a successful state transition
 	RecordTransition(from, to T, duration time.Duration, metadata map[string]interface{})
-	
+
 	// RecordTransitionError records a failed state transition
 	RecordTransitionError(from, to T, err error, metadata map[string]interface{})
-	
+
 	// RecordCurrentState updates the current state metric
 	RecordCurrentState(state T)
-	
+
 	// RecordStateDuration records time spent in a state
 	RecordStateDuration(state T, duration time.Duration)
 }
@@ -116,22 +116,22 @@ type StateMetrics[T comparable] interface {
 type StateMachineConfig[T comparable] struct {
 	// InitialState is the starting state
 	InitialState T
-	
+
 	// TransitionRules define valid state transitions
 	TransitionRules TransitionRules[T]
-	
+
 	// Validator for custom transition validation (optional)
 	Validator StateValidator[T]
-	
+
 	// Metrics collector for state machine operations (optional)
 	Metrics StateMetrics[T]
-	
+
 	// MaxHistorySize limits the number of transitions to keep in history
 	MaxHistorySize int
-	
+
 	// EnableMetrics controls whether to collect and emit metrics
 	EnableMetrics bool
-	
+
 	// Name is a human-readable identifier for this state machine instance
 	Name string
 }

--- a/synckit/sync.go
+++ b/synckit/sync.go
@@ -8,10 +8,10 @@ import (
 	"log/slog"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	"github.com/c0deZ3R0/go-sync-kit/cursor"
-	"github.com/c0deZ3R0/go-sync-kit/synckit/types"
 	"github.com/c0deZ3R0/go-sync-kit/synckit/statemachine"
+	"github.com/c0deZ3R0/go-sync-kit/synckit/types"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Event represents a syncable event in the system.
@@ -245,7 +245,7 @@ func NewSyncManager(store EventStore, transport Transport, opts *SyncOptions, lo
 		// Log the error but don't fail - state machine is optional enhancement
 		logger.Warn("Failed to create sync state machine, continuing without state tracking", "error", err)
 	}
-	
+
 	sm := &syncManager{
 		store:            store,
 		transport:        transport,
@@ -254,7 +254,7 @@ func NewSyncManager(store EventStore, transport Transport, opts *SyncOptions, lo
 		stateMachine:     stateMachine,
 		projectionConfig: projectionConfig,
 	}
-	
+
 	// Initialize projection worker pool if projections are configured
 	if projectionConfig != nil && projectionConfig.RunOnSync && len(projectionConfig.Runners) > 0 {
 		sm.projectionPool = make(chan struct{}, projectionConfig.MaxWorkers)
@@ -264,7 +264,7 @@ func NewSyncManager(store EventStore, transport Transport, opts *SyncOptions, lo
 			"timeout", projectionConfig.Timeout,
 		)
 	}
-	
+
 	return sm
 }
 
@@ -275,22 +275,22 @@ func createSyncStateMachine(metricsCollector MetricsCollector, tracer interface{
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// If no observability components provided, return basic state machine
 	if metricsCollector == nil && tracer == nil {
 		return basicStateMachine, nil
 	}
-	
+
 	// Create observability adapters
 	var stateMetrics statemachine.StateMetricsCollector
 	var stateTracer statemachine.StateTracer
 	var healthUpdater statemachine.StateHealthUpdater
-	
+
 	// Setup metrics adapter
 	if metricsCollector != nil {
 		stateMetrics = statemachine.NewSyncKitMetricsAdapter(metricsCollector)
 	}
-	
+
 	// Setup tracing adapter if available
 	if tracer != nil {
 		// Try to cast to the expected tracer interface
@@ -302,12 +302,12 @@ func createSyncStateMachine(metricsCollector MetricsCollector, tracer interface{
 			stateTracer = statemachine.NewSyncKitTracerAdapter(syncTracer)
 		}
 	}
-	
+
 	// Create default health updater (placeholder for future health check integration)
 	if logger != nil {
 		healthUpdater = statemachine.NewDefaultStateHealthUpdater(nil) // nil for now, can be enhanced later
 	}
-	
+
 	// Create observability hooks
 	hooks := statemachine.NewObservabilityHooks[SyncState](
 		stateMetrics,
@@ -316,9 +316,9 @@ func createSyncStateMachine(metricsCollector MetricsCollector, tracer interface{
 		logger,
 		"sync_manager",
 	)
-	
+
 	// Subscribe observability hooks to the state machine
 	basicStateMachine.Subscribe(hooks)
-	
+
 	return basicStateMachine, nil
 }

--- a/synckit/sync_state.go
+++ b/synckit/sync_state.go
@@ -3,7 +3,7 @@ package synckit
 import (
 	"fmt"
 	"time"
-	
+
 	"github.com/c0deZ3R0/go-sync-kit/synckit/statemachine"
 )
 
@@ -13,25 +13,25 @@ type SyncState int
 const (
 	// SyncIdle indicates the sync manager is ready for new operations
 	SyncIdle SyncState = iota
-	
+
 	// SyncInitializing indicates a sync operation is being set up
 	SyncInitializing
-	
+
 	// SyncPushing indicates local events are being sent to remote
 	SyncPushing
-	
+
 	// SyncPulling indicates remote events are being retrieved
 	SyncPulling
-	
+
 	// SyncResolvingConflicts indicates conflicts are being processed
 	SyncResolvingConflicts
-	
+
 	// SyncCompleted indicates the sync operation completed successfully
 	SyncCompleted
-	
+
 	// SyncFailed indicates the sync operation failed
 	SyncFailed
-	
+
 	// SyncCancelled indicates the sync operation was cancelled
 	SyncCancelled
 )
@@ -80,19 +80,19 @@ func SyncStateTransitionRules() statemachine.TransitionRules[SyncState] {
 	return statemachine.TransitionRules[SyncState]{
 		// From Idle, can start a new sync operation
 		SyncIdle: {SyncInitializing},
-		
+
 		// From Initializing, can go to push/pull phases or fail/cancel
 		SyncInitializing: {SyncPushing, SyncPulling, SyncFailed, SyncCancelled},
-		
+
 		// From Pushing, can proceed to pull, complete, or fail/cancel
 		SyncPushing: {SyncPulling, SyncCompleted, SyncFailed, SyncCancelled},
-		
+
 		// From Pulling, can proceed to push, resolve conflicts, complete, or fail/cancel
 		SyncPulling: {SyncPushing, SyncResolvingConflicts, SyncCompleted, SyncFailed, SyncCancelled},
-		
+
 		// From Resolving Conflicts, can complete or fail/cancel
 		SyncResolvingConflicts: {SyncCompleted, SyncFailed, SyncCancelled},
-		
+
 		// Terminal states can only return to Idle
 		SyncCompleted: {SyncIdle},
 		SyncFailed:    {SyncIdle},
@@ -119,7 +119,7 @@ func NewSyncStateMachine() (statemachine.StateMachine[SyncState], error) {
 type SyncStateObserver struct {
 	// OnStateChange is called when a sync state transition succeeds
 	OnStateChange func(from, to SyncState, duration time.Duration, metadata map[string]interface{})
-	
+
 	// OnStateChangeError is called when a sync state transition fails
 	OnStateChangeError func(from, to SyncState, err error, metadata map[string]interface{})
 }
@@ -141,13 +141,13 @@ func (o *SyncStateObserver) OnTransitionFailed(from, to SyncState, err error, me
 // StateAwareSyncResult extends SyncResult with state machine information.
 type StateAwareSyncResult struct {
 	*SyncResult
-	
+
 	// StateTransitions contains the state transitions that occurred during sync
 	StateTransitions []statemachine.StateTransition[SyncState]
-	
+
 	// FinalState is the final state of the sync operation
 	FinalState SyncState
-	
+
 	// StateChanges is the number of state transitions that occurred
 	StateChanges int
 }
@@ -155,10 +155,10 @@ type StateAwareSyncResult struct {
 // NewStateAwareSyncResult creates a StateAwareSyncResult from a regular SyncResult and state machine history.
 func NewStateAwareSyncResult(result *SyncResult, stateMachine statemachine.StateMachine[SyncState]) *StateAwareSyncResult {
 	history := stateMachine.History()
-	
+
 	// Find transitions that occurred during this sync operation
 	var syncTransitions []statemachine.StateTransition[SyncState]
-	
+
 	// Look for transitions from the start time of the sync operation
 	if result != nil {
 		for _, transition := range history {
@@ -167,7 +167,7 @@ func NewStateAwareSyncResult(result *SyncResult, stateMachine statemachine.State
 			}
 		}
 	}
-	
+
 	return &StateAwareSyncResult{
 		SyncResult:       result,
 		StateTransitions: syncTransitions,

--- a/synckit/sync_test.go
+++ b/synckit/sync_test.go
@@ -137,9 +137,9 @@ type MockConflictResolver struct{}
 
 func (m *MockConflictResolver) Resolve(ctx context.Context, conflict Conflict) (ResolvedConflict, error) {
 	return ResolvedConflict{
-		Decision:        "use_remote", 
-		ResolvedEvents:  []EventWithVersion{conflict.Remote},
-		Reasons:         []string{"mock resolver chose remote"},
+		Decision:       "use_remote",
+		ResolvedEvents: []EventWithVersion{conflict.Remote},
+		Reasons:        []string{"mock resolver chose remote"},
 	}, nil
 }
 

--- a/synckit/test_helpers.go
+++ b/synckit/test_helpers.go
@@ -178,10 +178,16 @@ func (m *MockMetricsCollector) RecordConflicts(resolved int) {
 }
 
 // Snapshot helpers for thread-safe reads in tests
-func (m *MockMetricsCollector) CopyDurationCalls() []struct{ Operation string; Duration time.Duration } {
+func (m *MockMetricsCollector) CopyDurationCalls() []struct {
+	Operation string
+	Duration  time.Duration
+} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]struct{ Operation string; Duration time.Duration }, len(m.DurationCalls))
+	out := make([]struct {
+		Operation string
+		Duration  time.Duration
+	}, len(m.DurationCalls))
 	copy(out, m.DurationCalls)
 	return out
 }

--- a/transport/httptransport/benchmark_test.go
+++ b/transport/httptransport/benchmark_test.go
@@ -32,7 +32,7 @@ func BenchmarkCompressionThresholds(b *testing.B) {
 func benchmarkCompressionThreshold(b *testing.B, compressionThreshold int64, batchSize int) {
 	// Create mock store
 	store := NewMockEventStore()
-	
+
 	// Create server with specific compression threshold
 	serverOpts := &ServerOptions{
 		MaxRequestSize:       10 * 1024 * 1024, // 10MB
@@ -40,25 +40,25 @@ func benchmarkCompressionThreshold(b *testing.B, compressionThreshold int64, bat
 		CompressionEnabled:   true,
 		CompressionThreshold: compressionThreshold,
 	}
-	
+
 	handler := NewSyncHandler(store, slog.Default(), nil, serverOpts)
-	
+
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(handler.handlePush))
 	defer server.Close()
-	
+
 	// Generate test events for the batch
 	events := generateTestEvents(batchSize)
-	
+
 	// Marshal events to JSON to get the actual payload size
 	data, err := json.Marshal(events)
 	if err != nil {
 		b.Fatal(err)
 	}
-	
+
 	b.ResetTimer()
 	b.SetBytes(int64(len(data))) // Set bytes processed per operation
-	
+
 	// Benchmark the push operation
 	for i := 0; i < b.N; i++ {
 		// Test uncompressed request
@@ -67,13 +67,13 @@ func benchmarkCompressionThreshold(b *testing.B, compressionThreshold int64, bat
 			b.Fatal(err)
 		}
 		req.Header.Set("Content-Type", "application/json")
-		
+
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			b.Fatal(err)
 		}
 		resp.Body.Close()
-		
+
 		if resp.StatusCode != http.StatusOK {
 			b.Fatalf("Expected 200, got %d", resp.StatusCode)
 		}
@@ -91,9 +91,9 @@ func BenchmarkCompressionRatio(b *testing.B) {
 		{"Random", generateRandomEvents},
 		{"Mixed", generateMixedEvents},
 	}
-	
+
 	payloadSizes := []int{100, 500, 1000, 2000}
-	
+
 	for _, payloadType := range payloadTypes {
 		for _, size := range payloadSizes {
 			b.Run(fmt.Sprintf("%s_%devents", payloadType.name, size), func(b *testing.B) {
@@ -109,13 +109,13 @@ func benchmarkCompressionRatio(b *testing.B, dataFunc func(int) []JSONEventWithV
 	if err != nil {
 		b.Fatal(err)
 	}
-	
+
 	b.ResetTimer()
 	b.SetBytes(int64(len(data)))
-	
+
 	var totalCompressed int64
 	var totalUncompressed int64
-	
+
 	for i := 0; i < b.N; i++ {
 		// Compress the data
 		var compressed bytes.Buffer
@@ -125,11 +125,11 @@ func benchmarkCompressionRatio(b *testing.B, dataFunc func(int) []JSONEventWithV
 			b.Fatal(err)
 		}
 		gzWriter.Close()
-		
+
 		totalUncompressed += int64(len(data))
 		totalCompressed += int64(compressed.Len())
 	}
-	
+
 	// Report compression ratio in the benchmark name
 	ratio := float64(totalCompressed) / float64(totalUncompressed)
 	b.ReportMetric(ratio, "compression_ratio")
@@ -147,12 +147,12 @@ func BenchmarkSafeRequestReader(b *testing.B) {
 	}{
 		{"Small_Uncompressed_1KB", false, 1024, 2048},
 		{"Small_Compressed_1KB", true, 1024, 512},
-		{"Medium_Uncompressed_10KB", false, 10*1024, 2048},
-		{"Medium_Compressed_10KB", true, 10*1024, 512},
-		{"Large_Uncompressed_100KB", false, 100*1024, 2048},
-		{"Large_Compressed_100KB", true, 100*1024, 512},
+		{"Medium_Uncompressed_10KB", false, 10 * 1024, 2048},
+		{"Medium_Compressed_10KB", true, 10 * 1024, 512},
+		{"Large_Uncompressed_100KB", false, 100 * 1024, 2048},
+		{"Large_Compressed_100KB", true, 100 * 1024, 512},
 	}
-	
+
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, func(b *testing.B) {
 			benchmarkSafeRequestReader(b, scenario.compressed, scenario.payloadSize, scenario.threshold)
@@ -163,10 +163,10 @@ func BenchmarkSafeRequestReader(b *testing.B) {
 func benchmarkSafeRequestReader(b *testing.B, compressed bool, payloadSize int, threshold int64) {
 	// Generate test payload
 	testData := strings.Repeat("A", payloadSize)
-	
+
 	var requestBody []byte
 	contentEncoding := ""
-	
+
 	if compressed {
 		var buf bytes.Buffer
 		gzWriter := gzip.NewWriter(&buf)
@@ -177,34 +177,34 @@ func benchmarkSafeRequestReader(b *testing.B, compressed bool, payloadSize int, 
 	} else {
 		requestBody = []byte(testData)
 	}
-	
+
 	serverOpts := &ServerOptions{
-		MaxRequestSize:      10 * 1024 * 1024, // 10MB
-		MaxDecompressedSize: 20 * 1024 * 1024, // 20MB
+		MaxRequestSize:       10 * 1024 * 1024, // 10MB
+		MaxDecompressedSize:  20 * 1024 * 1024, // 20MB
 		CompressionThreshold: threshold,
 	}
-	
+
 	b.ResetTimer()
 	b.SetBytes(int64(len(requestBody)))
-	
+
 	for i := 0; i < b.N; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(requestBody))
 		req.Header.Set("Content-Type", "application/json")
 		if contentEncoding != "" {
 			req.Header.Set("Content-Encoding", contentEncoding)
 		}
-		
+
 		w := httptest.NewRecorder()
-		
+
 		reader, cleanup, err := createSafeRequestReader(w, req, serverOpts)
 		if err != nil {
 			b.Fatal(err)
 		}
-		
+
 		// Read all data to benchmark the full pipeline
 		_, err = bytes.NewBuffer(nil).ReadFrom(reader)
 		cleanup()
-		
+
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -292,7 +292,7 @@ func generateMixedEvents(count int) []JSONEventWithVersion {
 			// Other events are more random
 			data = fmt.Sprintf("Unique data for event %d with timestamp %d", i, i*7919)
 		}
-		
+
 		events[i] = JSONEventWithVersion{
 			Event: JSONEvent{
 				ID:          fmt.Sprintf("mixed-%d", i),
@@ -300,9 +300,9 @@ func generateMixedEvents(count int) []JSONEventWithVersion {
 				AggregateID: fmt.Sprintf("mixed-agg-%d", i%15),
 				Data:        data,
 				Metadata: map[string]interface{}{
-					"index":      i,
-					"is_common":  i%3 == 0,
-					"batch":      i / 10,
+					"index":     i,
+					"is_common": i%3 == 0,
+					"batch":     i / 10,
 				},
 			},
 			Version: fmt.Sprintf("%d", i+1),

--- a/transport/httptransport/client.go
+++ b/transport/httptransport/client.go
@@ -126,7 +126,7 @@ func (c *TransportClient) ToHTTPTransport() *HTTPTransport {
 	if c.parseVersion != nil {
 		versionParser = VersionParser(c.parseVersion)
 	}
-	
+
 	// Use the existing NewTransportWithLogger to create HTTPTransport
 	return NewTransportWithLogger(c.baseURL, c.http, versionParser, clientOptions, nil)
 }
@@ -171,7 +171,7 @@ func NewTransportWithLogger(baseURL string, client *http.Client, parser VersionP
 		options.MaxDecompressedResponseSize = 20 * 1024 * 1024
 	}
 	// Note: GzipMinBytes can be 0 intentionally, so we don't set a default here
-	
+
 	// Validate client options
 	if err := ValidateClientOptions(options); err != nil {
 		// For backward compatibility, we'll just use default options if validation fails
@@ -208,8 +208,8 @@ func NewTransportWithLogger(baseURL string, client *http.Client, parser VersionP
 
 // Push sends a batch of events to the remote server via an HTTP POST request.
 //
-// Note: If CompressionEnabled is true in ClientOptions and the payload size exceeds 
-// GzipMinBytes, the client will compress JSON request bodies using gzip and set the 
+// Note: If CompressionEnabled is true in ClientOptions and the payload size exceeds
+// GzipMinBytes, the client will compress JSON request bodies using gzip and set the
 // "Content-Encoding: gzip" header. It also sets "Accept-Encoding" header to
 // indicate support for gzip and deflate compressed responses.
 //
@@ -267,12 +267,12 @@ func (c *HTTPTransport) Push(ctx context.Context, events []synckit.EventWithVers
 				slog.String("error", err.Error()))
 			return syncErrors.WrapOpComponent(fmt.Errorf("failed to close gzip writer: %w", err), "httptransport.Push", "transport/httptransport")
 		}
-		
+
 		req.Body = io.NopCloser(&buf)
 		req.Header.Set("Content-Encoding", "gzip")
 		// Optionally set Content-Length
 		req.ContentLength = int64(buf.Len())
-		
+
 		c.logger.Debug("Compressed push request",
 			slog.Int("original_size", len(payload)),
 			slog.Int("compressed_size", buf.Len()),

--- a/transport/httptransport/client_gzip_test.go
+++ b/transport/httptransport/client_gzip_test.go
@@ -18,53 +18,53 @@ import (
 // TestPushGzipCompressionThreshold tests that outbound requests are compressed when payload exceeds threshold
 func TestPushGzipCompressionThreshold(t *testing.T) {
 	tests := []struct {
-		name             string
-		gzipMinBytes     int
-		payloadSize      int
+		name               string
+		gzipMinBytes       int
+		payloadSize        int
 		compressionEnabled bool
-		expectCompressed bool
+		expectCompressed   bool
 	}{
 		{
-			name:             "small payload, default threshold - not compressed",
-			gzipMinBytes:     0, // Default 1KB
-			payloadSize:      500,
+			name:               "small payload, default threshold - not compressed",
+			gzipMinBytes:       0, // Default 1KB
+			payloadSize:        500,
 			compressionEnabled: true,
-			expectCompressed: false,
+			expectCompressed:   false,
 		},
 		{
-			name:             "large payload, default threshold - compressed",
-			gzipMinBytes:     0, // Default 1KB
-			payloadSize:      2000,
+			name:               "large payload, default threshold - compressed",
+			gzipMinBytes:       0, // Default 1KB
+			payloadSize:        2000,
 			compressionEnabled: true,
-			expectCompressed: true,
+			expectCompressed:   true,
 		},
 		{
-			name:             "small payload, custom low threshold - compressed",
-			gzipMinBytes:     100,
-			payloadSize:      200,
+			name:               "small payload, custom low threshold - compressed",
+			gzipMinBytes:       100,
+			payloadSize:        200,
 			compressionEnabled: true,
-			expectCompressed: true,
+			expectCompressed:   true,
 		},
 		{
-			name:             "large payload, custom high threshold - not compressed",
-			gzipMinBytes:     5000,
-			payloadSize:      2000,
+			name:               "large payload, custom high threshold - not compressed",
+			gzipMinBytes:       5000,
+			payloadSize:        2000,
 			compressionEnabled: true,
-			expectCompressed: false,
+			expectCompressed:   false,
 		},
 		{
-			name:             "large payload, compression disabled - not compressed",
-			gzipMinBytes:     0,
-			payloadSize:      2000,
+			name:               "large payload, compression disabled - not compressed",
+			gzipMinBytes:       0,
+			payloadSize:        2000,
 			compressionEnabled: false,
-			expectCompressed: false,
+			expectCompressed:   false,
 		},
 		{
-			name:             "zero threshold, large payload - compressed",
-			gzipMinBytes:     0,
-			payloadSize:      1500,
+			name:               "zero threshold, large payload - compressed",
+			gzipMinBytes:       0,
+			payloadSize:        1500,
 			compressionEnabled: true,
-			expectCompressed: true,
+			expectCompressed:   true,
 		},
 	}
 
@@ -77,7 +77,7 @@ func TestPushGzipCompressionThreshold(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				receivedContentEncoding = r.Header.Get("Content-Encoding")
-				
+
 				// Read the body
 				body, err := io.ReadAll(r.Body)
 				if err != nil {
@@ -94,7 +94,7 @@ func TestPushGzipCompressionThreshold(t *testing.T) {
 						return
 					}
 					defer reader.Close()
-					
+
 					_, err = io.ReadAll(reader)
 					isBodyGzipped = err == nil
 				}
@@ -149,7 +149,7 @@ func TestPushGzipCompressionThreshold(t *testing.T) {
 // TestPushGzipWithCustomThreshold tests the WithGzipThreshold option
 func TestPushGzipWithCustomThreshold(t *testing.T) {
 	var receivedContentEncoding string
-	
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedContentEncoding = r.Header.Get("Content-Encoding")
 		w.WriteHeader(http.StatusOK)
@@ -183,7 +183,7 @@ func TestPushGzipWithCustomThreshold(t *testing.T) {
 // TestPushGzipDisabled tests that compression is disabled when CompressionEnabled is false
 func TestPushGzipDisabled(t *testing.T) {
 	var receivedContentEncoding string
-	
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedContentEncoding = r.Header.Get("Content-Encoding")
 		w.WriteHeader(http.StatusOK)
@@ -217,7 +217,7 @@ func TestPushGzipDisabled(t *testing.T) {
 func TestPushGzipContentType(t *testing.T) {
 	var receivedContentType string
 	var receivedContentEncoding string
-	
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedContentType = r.Header.Get("Content-Type")
 		receivedContentEncoding = r.Header.Get("Content-Encoding")
@@ -251,9 +251,9 @@ func TestPushGzipContentType(t *testing.T) {
 // TestPushGzipAcceptEncoding tests that Accept-Encoding header is set correctly
 func TestPushGzipAcceptEncoding(t *testing.T) {
 	tests := []struct {
-		name                       string
-		disableAutoDecompression   bool
-		expectedAcceptEncoding     string
+		name                     string
+		disableAutoDecompression bool
+		expectedAcceptEncoding   string
 	}{
 		{
 			name:                     "auto decompression enabled",
@@ -270,7 +270,7 @@ func TestPushGzipAcceptEncoding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedAcceptEncoding string
-			
+
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				receivedAcceptEncoding = r.Header.Get("Accept-Encoding")
 				w.WriteHeader(http.StatusOK)
@@ -279,9 +279,9 @@ func TestPushGzipAcceptEncoding(t *testing.T) {
 			defer server.Close()
 
 			options := &ClientOptions{
-				CompressionEnabled:        true,
-				DisableAutoDecompression:  tt.disableAutoDecompression,
-				GzipMinBytes:              100,
+				CompressionEnabled:       true,
+				DisableAutoDecompression: tt.disableAutoDecompression,
+				GzipMinBytes:             100,
 			}
 
 			transport := NewTransport(server.URL, nil, nil, options)
@@ -326,14 +326,14 @@ func TestGzipValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			options := &ClientOptions{
-				CompressionEnabled: true,
-				GzipMinBytes:       tt.gzipMinBytes,
-				MaxResponseSize:    10 * 1024 * 1024, // Required field
+				CompressionEnabled:          true,
+				GzipMinBytes:                tt.gzipMinBytes,
+				MaxResponseSize:             10 * 1024 * 1024, // Required field
 				MaxDecompressedResponseSize: 20 * 1024 * 1024, // Required field
 			}
 
 			err := ValidateClientOptions(options)
-			
+
 			if tt.expectError && err == nil {
 				t.Error("Expected validation error, but got none")
 			}
@@ -348,16 +348,16 @@ func TestGzipValidation(t *testing.T) {
 func createEventsWithSize(targetSize int) []synckit.EventWithVersion {
 	// Estimate bytes per event (JSON overhead + data)
 	bytesPerEvent := 200 // Rough estimate including JSON structure
-	
+
 	numEvents := max(1, targetSize/bytesPerEvent)
-	
+
 	events := make([]synckit.EventWithVersion, numEvents)
-	
+
 	for i := 0; i < numEvents; i++ {
 		// Create event with some data to reach target size
 		dataSize := max(10, (targetSize/numEvents)-150) // Account for JSON overhead
 		data := strings.Repeat("x", dataSize)
-		
+
 		event := &SimpleEvent{
 			IDValue:          fmt.Sprintf("event-%d", i),
 			TypeValue:        "test.event",
@@ -365,13 +365,13 @@ func createEventsWithSize(targetSize int) []synckit.EventWithVersion {
 			DataValue:        data,
 			MetadataValue:    map[string]interface{}{"test": true},
 		}
-		
+
 		events[i] = synckit.EventWithVersion{
 			Event:   event,
 			Version: cursor.IntegerCursor{Seq: uint64(i + 1)},
 		}
 	}
-	
+
 	return events
 }
 

--- a/transport/httptransport/client_test.go
+++ b/transport/httptransport/client_test.go
@@ -102,7 +102,7 @@ func TestWithLimitsOverride(t *testing.T) {
 // TestWithVersionParser tests that WithVersionParser option properly sets the version parser
 func TestWithVersionParser(t *testing.T) {
 	baseURL := "http://example.com/sync"
-	
+
 	// Create a custom version parser function
 	customParser := func(ctx context.Context, s string) (synckit.Version, error) {
 		v, err := strconv.ParseInt(s, 10, 64)
@@ -238,14 +238,14 @@ func TestToHTTPTransport(t *testing.T) {
 // TestOptionsOrdering tests that the last option takes precedence when options conflict
 func TestOptionsOrdering(t *testing.T) {
 	baseURL := "http://example.com/sync"
-	
+
 	firstLimits := Limits{
 		MaxBodyBytes:         8 << 20,
 		MaxDecompressedBytes: 64 << 20,
 		EnableGzip:           true,
 		GzipMinBytes:         2 << 20,
 	}
-	
+
 	secondLimits := Limits{
 		MaxBodyBytes:         16 << 20,
 		MaxDecompressedBytes: 128 << 20,

--- a/transport/httptransport/gzip_fuzz_test.go
+++ b/transport/httptransport/gzip_fuzz_test.go
@@ -19,26 +19,26 @@ func FuzzCreateSafeRequestReader(f *testing.F) {
 	gzWriter := gzip.NewWriter(&validGzipBuf)
 	gzWriter.Write([]byte(validPayload))
 	gzWriter.Close()
-	
+
 	f.Add(validGzipBuf.Bytes(), "application/json", "gzip")
 	f.Add([]byte(validPayload), "application/json", "")
 	f.Add([]byte(""), "application/json", "gzip")
 	f.Add([]byte("not gzip"), "application/json", "gzip")
-	
+
 	// Add some malformed gzip headers
 	f.Add([]byte{0x1f, 0x8b, 0x08, 0x00}, "application/json", "gzip") // Truncated gzip header
 	f.Add([]byte{0x1f, 0x8b}, "application/json", "gzip")             // Very short
 	f.Add([]byte{0x00, 0x00, 0x00, 0x00}, "application/json", "gzip") // Wrong magic numbers
-	
+
 	f.Fuzz(func(t *testing.T, data []byte, contentType, contentEncoding string) {
 		// Test that createSafeRequestReader doesn't panic on arbitrary input
 		defer func() {
 			if r := recover(); r != nil {
-				t.Errorf("createSafeRequestReader panicked on input len=%d, ct=%q, ce=%q: %v", 
+				t.Errorf("createSafeRequestReader panicked on input len=%d, ct=%q, ce=%q: %v",
 					len(data), contentType, contentEncoding, r)
 			}
 		}()
-		
+
 		// Create a test request with the fuzzed data
 		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(data))
 		if contentType != "" {
@@ -47,30 +47,30 @@ func FuzzCreateSafeRequestReader(f *testing.F) {
 		if contentEncoding != "" {
 			req.Header.Set("Content-Encoding", contentEncoding)
 		}
-		
+
 		w := httptest.NewRecorder()
-		
+
 		// Test with default server options
 		serverOpts := DefaultServerOptions()
-		
+
 		// Create the safe request reader
 		reader, cleanup, err := createSafeRequestReader(w, req, serverOpts)
-		
+
 		// cleanup should always be callable, even if err != nil
 		if cleanup != nil {
 			defer cleanup()
 		}
-		
+
 		if err != nil {
 			// Errors are acceptable for invalid input
 			return
 		}
-		
+
 		if reader == nil {
 			t.Error("createSafeRequestReader returned nil reader with no error")
 			return
 		}
-		
+
 		// Try to read from the reader without panicking
 		buffer := make([]byte, 1024)
 		for {
@@ -97,57 +97,57 @@ func FuzzGzipDecompression(f *testing.F) {
 	gzWriter := gzip.NewWriter(&validBuf)
 	gzWriter.Write([]byte(validData))
 	gzWriter.Close()
-	
+
 	// Seed with valid and some invalid patterns
 	f.Add(validBuf.Bytes())
 	f.Add([]byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff}) // Minimal gzip header
-	f.Add([]byte{0x1f, 0x8b}) // Just magic numbers
-	f.Add([]byte{}) // Empty data
+	f.Add([]byte{0x1f, 0x8b})                                                 // Just magic numbers
+	f.Add([]byte{})                                                           // Empty data
 	f.Add([]byte("not gzip at all"))
-	
+
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("Gzip decompression panicked on input len=%d: %v", len(data), r)
 			}
 		}()
-		
+
 		// Create a request with gzip content-encoding
 		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Content-Encoding", "gzip")
-		
+
 		w := httptest.NewRecorder()
 		serverOpts := &ServerOptions{
-			MaxRequestSize:      10 * 1024,    // 10KB
-			MaxDecompressedSize: 20 * 1024,    // 20KB
+			MaxRequestSize:      10 * 1024, // 10KB
+			MaxDecompressedSize: 20 * 1024, // 20KB
 			CompressionEnabled:  true,
 		}
-		
+
 		reader, cleanup, err := createSafeRequestReader(w, req, serverOpts)
 		if cleanup != nil {
 			defer cleanup()
 		}
-		
+
 		if err != nil {
 			// Errors are expected for invalid gzip data
 			return
 		}
-		
+
 		if reader == nil {
 			t.Error("Expected reader or error, got nil reader with no error")
 			return
 		}
-		
+
 		// Try to read all data
 		output, readErr := io.ReadAll(reader)
-		
+
 		// ReadAll should either succeed or fail gracefully
 		if readErr != nil && readErr != io.EOF {
 			// Read errors are acceptable for malformed gzip
 			return
 		}
-		
+
 		// If we got output, it should be reasonable
 		if int64(len(output)) > serverOpts.MaxDecompressedSize {
 			t.Errorf("Decompressed data size %d exceeds limit %d", len(output), serverOpts.MaxDecompressedSize)
@@ -161,34 +161,34 @@ func FuzzCompressionSizeLimits(f *testing.F) {
 	smallData := strings.Repeat("a", 100)
 	mediumData := strings.Repeat("b", 1000)
 	largeData := strings.Repeat("c", 10000)
-	
+
 	// Create gzipped versions
 	var smallBuf, mediumBuf, largeBuf bytes.Buffer
-	
+
 	gzSmall := gzip.NewWriter(&smallBuf)
 	gzSmall.Write([]byte(smallData))
 	gzSmall.Close()
-	
+
 	gzMedium := gzip.NewWriter(&mediumBuf)
 	gzMedium.Write([]byte(mediumData))
 	gzMedium.Close()
-	
+
 	gzLarge := gzip.NewWriter(&largeBuf)
 	gzLarge.Write([]byte(largeData))
 	gzLarge.Close()
-	
+
 	f.Add(smallBuf.Bytes(), int64(500), int64(1000))   // Within limits
 	f.Add(mediumBuf.Bytes(), int64(2000), int64(4000)) // Within limits
 	f.Add(largeBuf.Bytes(), int64(500), int64(1000))   // Exceeds limits
 	f.Add(largeBuf.Bytes(), int64(15000), int64(5000)) // Decompressed exceeds limit
-	
+
 	f.Fuzz(func(t *testing.T, data []byte, maxRequestSize, maxDecompressedSize int64) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("Size limit enforcement panicked: %v", r)
 			}
 		}()
-		
+
 		// Ensure positive limits
 		if maxRequestSize <= 0 {
 			maxRequestSize = 1024
@@ -196,61 +196,61 @@ func FuzzCompressionSizeLimits(f *testing.F) {
 		if maxDecompressedSize <= 0 {
 			maxDecompressedSize = 2048
 		}
-		
+
 		req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Content-Encoding", "gzip")
-		
+
 		w := httptest.NewRecorder()
 		serverOpts := &ServerOptions{
 			MaxRequestSize:      maxRequestSize,
 			MaxDecompressedSize: maxDecompressedSize,
 			CompressionEnabled:  true,
 		}
-		
+
 		reader, cleanup, err := createSafeRequestReader(w, req, serverOpts)
 		if cleanup != nil {
 			defer cleanup()
 		}
-		
+
 		// Test size limit enforcement
 		if int64(len(data)) > maxRequestSize {
 			// Should get an error for oversized compressed data
 			if err == nil {
-				t.Errorf("Expected error for compressed data size %d > limit %d", 
+				t.Errorf("Expected error for compressed data size %d > limit %d",
 					len(data), maxRequestSize)
 			}
 			return
 		}
-		
+
 		if err != nil {
 			// Other errors are acceptable (e.g., invalid gzip)
 			return
 		}
-		
+
 		if reader == nil {
 			t.Error("Expected reader or error, got neither")
 			return
 		}
-		
+
 		// Try to read and verify decompression limit is enforced
 		output, readErr := io.ReadAll(reader)
-		
+
 		if readErr != nil {
 			// Check if it's a decompression limit error
-			if strings.Contains(readErr.Error(), "decompressed") || 
-			   strings.Contains(readErr.Error(), "exceeds") ||
-			   strings.Contains(readErr.Error(), "limit") {
+			if strings.Contains(readErr.Error(), "decompressed") ||
+				strings.Contains(readErr.Error(), "exceeds") ||
+				strings.Contains(readErr.Error(), "limit") {
 				// This is expected for data that exceeds decompression limits
 				return
 			}
 			// Other read errors are acceptable for malformed gzip
 			return
 		}
-		
+
 		// If read succeeded, check the size
 		if int64(len(output)) > maxDecompressedSize {
-			t.Errorf("Decompressed output size %d exceeds limit %d", 
+			t.Errorf("Decompressed output size %d exceeds limit %d",
 				len(output), maxDecompressedSize)
 		}
 	})
@@ -266,18 +266,18 @@ func FuzzMaxDecompressedReader(f *testing.F) {
 		"",
 		"Single byte",
 	}
-	
+
 	for _, data := range testData {
 		f.Add(data, int64(100), int64(500), int64(1000))
 	}
-	
+
 	f.Fuzz(func(t *testing.T, data string, limit1, limit2, limit3 int64) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("maxDecompressedReader panicked: %v", r)
 			}
 		}()
-		
+
 		// Ensure positive limits
 		limits := []int64{limit1, limit2, limit3}
 		for i, limit := range limits {
@@ -285,50 +285,50 @@ func FuzzMaxDecompressedReader(f *testing.F) {
 				limits[i] = 100
 			}
 		}
-		
+
 		for _, limit := range limits {
 			// Create a limited reader
 			reader := &maxDecompressedReader{
 				reader: strings.NewReader(data),
 				limit:  limit,
 			}
-			
+
 			// Try to read all data
 			output, err := io.ReadAll(reader)
-			
+
 			if err != nil {
 				// Check if it's the expected limit error
 				if err == errDecompressedTooLarge {
 					// This is expected when data exceeds limit
 					if int64(len(output)) > limit {
-						t.Errorf("Read %d bytes with limit %d, but got limit error", 
+						t.Errorf("Read %d bytes with limit %d, but got limit error",
 							len(output), limit)
 					}
 				}
 				// Other errors are acceptable
 				return
 			}
-			
+
 			// If no error, data should be within limit
 			if int64(len(output)) > limit {
-				t.Errorf("Read %d bytes exceeding limit %d without error", 
+				t.Errorf("Read %d bytes exceeding limit %d without error",
 					len(output), limit)
 			}
-			
+
 			// Verify the content is correct (up to the limit)
 			expectedLen := len(data)
 			if int64(expectedLen) > limit {
 				expectedLen = int(limit)
 			}
-			
+
 			if len(output) != expectedLen {
 				t.Errorf("Expected output length %d, got %d", expectedLen, len(output))
 			}
-			
+
 			if len(output) > 0 && expectedLen > 0 {
 				expectedContent := data[:expectedLen]
 				if string(output) != expectedContent {
-					t.Errorf("Content mismatch: expected %q, got %q", 
+					t.Errorf("Content mismatch: expected %q, got %q",
 						expectedContent, string(output))
 				}
 			}
@@ -347,14 +347,14 @@ func FuzzContentTypeValidation(f *testing.F) {
 	f.Add("invalid/content-type", "")
 	f.Add("application/json", "gzip")
 	f.Add("text/html", "gzip")
-	
+
 	f.Fuzz(func(t *testing.T, contentType, contentEncoding string) {
 		defer func() {
 			if r := recover(); r != nil {
 				t.Errorf("Content type validation panicked: %v", r)
 			}
 		}()
-		
+
 		// Create a simple request
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader("test data"))
 		if contentType != "" {
@@ -363,15 +363,15 @@ func FuzzContentTypeValidation(f *testing.F) {
 		if contentEncoding != "" {
 			req.Header.Set("Content-Encoding", contentEncoding)
 		}
-		
+
 		w := httptest.NewRecorder()
 		serverOpts := DefaultServerOptions()
-		
+
 		reader, cleanup, err := createSafeRequestReader(w, req, serverOpts)
 		if cleanup != nil {
 			defer cleanup()
 		}
-		
+
 		// Validate behavior based on content type
 		if contentType != "" && !strings.HasPrefix(contentType, "application/json") {
 			// Should get an error for unsupported media types

--- a/transport/httptransport/hooks_test.go
+++ b/transport/httptransport/hooks_test.go
@@ -341,7 +341,7 @@ func TestSyncHandler_BothHooks(t *testing.T) {
 		// Test push
 		eventData := []JSONEventWithVersion{
 			{
-				Event: JSONEvent{ID: "test-1", Type: "UserCreated"},
+				Event:   JSONEvent{ID: "test-1", Type: "UserCreated"},
 				Version: "1",
 			},
 		}

--- a/transport/httptransport/http.go
+++ b/transport/httptransport/http.go
@@ -16,12 +16,12 @@ import (
 
 // Operation constants for consistent error reporting
 const (
-	opPush         = "httptransport.Push"
-	opPull         = "httptransport.Pull"
+	opPush          = "httptransport.Push"
+	opPull          = "httptransport.Pull"
 	opLatestVersion = "httptransport.GetLatestVersion"
-	opSubscribe    = "httptransport.Subscribe"
-	opPushHandler  = "httptransport.handlePush"
-	opPullHandler  = "httptransport.handlePull"
+	opSubscribe     = "httptransport.Subscribe"
+	opPushHandler   = "httptransport.handlePush"
+	opPullHandler   = "httptransport.handlePull"
 	opLatestHandler = "httptransport.handleLatestVersion"
 )
 
@@ -34,7 +34,7 @@ type VersionParser func(ctx context.Context, s string) (synckit.Version, error)
 type SyncHooks struct {
 	// AfterCommit is called after events are successfully committed to storage
 	AfterCommit func(ctx context.Context, committed []synckit.EventWithVersion)
-	
+
 	// BeforePull is called before pulling events (for metrics, etc.)
 	BeforePull func(ctx context.Context, since synckit.Version)
 }
@@ -172,7 +172,7 @@ func (h *SyncHandler) handlePush(w http.ResponseWriter, r *http.Request) {
 
 	// Track successfully committed events for hooks
 	var committedEvents []synckit.EventWithVersion
-	
+
 	for _, jev := range jsonEvents {
 		ev, err := fromJSONEventWithVersion(r.Context(), h.versionParser, jev)
 		if err != nil {
@@ -203,21 +203,21 @@ func (h *SyncHandler) handlePush(w http.ResponseWriter, r *http.Request) {
 		slog.Int("event_count", len(jsonEvents)),
 		slog.Int("committed_count", len(committedEvents)),
 		slog.String("remote_addr", r.RemoteAddr))
-	
+
 	// Send response first
 	h.respond(w, r, http.StatusOK, map[string]string{"status": "ok"})
-	
+
 	// Call AfterCommit hook asynchronously if there are committed events
 	if h.hooks != nil && h.hooks.AfterCommit != nil && len(committedEvents) > 0 {
 		go func() {
 			// Create timeout context for hook execution
 			hookCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			
+
 			h.logger.Debug("Calling AfterCommit hook",
 				slog.Int("committed_events", len(committedEvents)),
 				slog.String("remote_addr", r.RemoteAddr))
-			
+
 			h.hooks.AfterCommit(hookCtx, committedEvents)
 		}()
 	}

--- a/transport/httptransport/server_safe_reader_test.go
+++ b/transport/httptransport/server_safe_reader_test.go
@@ -338,13 +338,13 @@ func TestSafeRequestReader_SizeLimits(t *testing.T) {
 					t.Error("expected reader but got nil")
 					return
 				}
-				
+
 				// Try to read all the data, expecting an error
 				buf := make([]byte, 1024)
 				totalRead := 0
 				var readErr error
 				var n int
-				
+
 				for readErr == nil {
 					n, readErr = reader.Read(buf)
 					totalRead += n
@@ -364,7 +364,7 @@ func TestSafeRequestReader_SizeLimits(t *testing.T) {
 						break
 					}
 				}
-				
+
 				if tt.expectedError && readErr == nil {
 					t.Error("expected error during reading but got none")
 				}

--- a/transport/httptransport/types.go
+++ b/transport/httptransport/types.go
@@ -165,7 +165,7 @@ type ClientOptions struct {
 func DefaultClientOptions() *ClientOptions {
 	return &ClientOptions{
 		CompressionEnabled:          true,
-		GzipMinBytes:                1024,              // 1KB
+		GzipMinBytes:                1024,             // 1KB
 		MaxResponseSize:             10 * 1024 * 1024, // 10MB
 		MaxDecompressedResponseSize: 20 * 1024 * 1024, // 20MB
 		RequestTimeout:              30 * time.Second, // 30s

--- a/transport/httptransport/wire_format.go
+++ b/transport/httptransport/wire_format.go
@@ -15,7 +15,7 @@ type WireEvent struct {
 	ID          string                 `json:"id"`
 	Type        string                 `json:"type"`
 	AggregateID string                 `json:"aggregate_id"`
-	Data        json.RawMessage        `json:"data"`         // Raw JSON for codec-aware or fallback encoding
+	Data        json.RawMessage        `json:"data"`                // Raw JSON for codec-aware or fallback encoding
 	DataKind    string                 `json:"data_kind,omitempty"` // Optional: codec identifier
 	Metadata    map[string]interface{} `json:"metadata"`
 }
@@ -54,7 +54,7 @@ func (e *CodecAwareEncoder) EncodeEvent(event synckit.Event) (WireEvent, error) 
 	}
 
 	data := event.Data()
-	
+
 	// Try to determine codec kind from metadata
 	var codecKind string
 	if metadata := event.Metadata(); metadata != nil {
@@ -104,7 +104,7 @@ func (e *CodecAwareEncoder) EncodeEvent(event synckit.Event) (WireEvent, error) 
 // DecodeEvent converts a WireEvent back to a concrete Event implementation.
 func (e *CodecAwareEncoder) DecodeEvent(wireEvent WireEvent) (synckit.Event, error) {
 	var data interface{}
-	
+
 	// If DataKind is specified, try to use the codec
 	if wireEvent.DataKind != "" {
 		if c, found := e.registry.Get(wireEvent.DataKind); found {

--- a/transport/httptransport/wire_format_test.go
+++ b/transport/httptransport/wire_format_test.go
@@ -79,9 +79,9 @@ func TestCodecAwareEncoder_EncodeEvent_WithCodec(t *testing.T) {
 	registry := codec.NewRegistry()
 	testCodec := &testCodec{kind: "test"}
 	registry.Register(testCodec)
-	
+
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	event := &testEvent{
 		id:          "test-1",
 		eventType:   "TestEvent",
@@ -91,19 +91,19 @@ func TestCodecAwareEncoder_EncodeEvent_WithCodec(t *testing.T) {
 			"kind": "test",
 		},
 	}
-	
+
 	wireEvent, err := encoder.EncodeEvent(event)
 	if err != nil {
 		t.Fatalf("EncodeEvent failed: %v", err)
 	}
-	
+
 	if wireEvent.ID != "test-1" {
 		t.Fatalf("Expected ID 'test-1', got %s", wireEvent.ID)
 	}
 	if wireEvent.DataKind != "test" {
 		t.Fatalf("Expected DataKind 'test', got %s", wireEvent.DataKind)
 	}
-	
+
 	// Verify the data was encoded with our test codec
 	var encoded string
 	if err := json.Unmarshal(wireEvent.Data, &encoded); err != nil {
@@ -117,7 +117,7 @@ func TestCodecAwareEncoder_EncodeEvent_WithCodec(t *testing.T) {
 func TestCodecAwareEncoder_EncodeEvent_Fallback(t *testing.T) {
 	registry := codec.NewRegistry()
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	event := &testEvent{
 		id:          "test-1",
 		eventType:   "TestEvent",
@@ -125,16 +125,16 @@ func TestCodecAwareEncoder_EncodeEvent_Fallback(t *testing.T) {
 		data:        "hello",
 		metadata:    map[string]interface{}{},
 	}
-	
+
 	wireEvent, err := encoder.EncodeEvent(event)
 	if err != nil {
 		t.Fatalf("EncodeEvent failed: %v", err)
 	}
-	
+
 	if wireEvent.DataKind != "" {
 		t.Fatalf("Expected no DataKind, got %s", wireEvent.DataKind)
 	}
-	
+
 	// Verify the data was encoded with JSON
 	var data interface{}
 	if err := json.Unmarshal(wireEvent.Data, &data); err != nil {
@@ -148,7 +148,7 @@ func TestCodecAwareEncoder_EncodeEvent_Fallback(t *testing.T) {
 func TestCodecAwareEncoder_EncodeEvent_NoFallback(t *testing.T) {
 	registry := codec.NewRegistry()
 	encoder := NewCodecAwareEncoder(registry, false)
-	
+
 	event := &testEvent{
 		id:          "test-1",
 		eventType:   "TestEvent",
@@ -158,7 +158,7 @@ func TestCodecAwareEncoder_EncodeEvent_NoFallback(t *testing.T) {
 			"kind": "unknown",
 		},
 	}
-	
+
 	_, err := encoder.EncodeEvent(event)
 	if err == nil {
 		t.Fatal("Expected error when codec not found and fallback disabled")
@@ -169,9 +169,9 @@ func TestCodecAwareEncoder_DecodeEvent_WithCodec(t *testing.T) {
 	registry := codec.NewRegistry()
 	testCodec := &testCodec{kind: "test"}
 	registry.Register(testCodec)
-	
+
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	// Create a wire event that was encoded with our test codec
 	data, _ := json.Marshal("PREFIX:hello")
 	wireEvent := WireEvent{
@@ -182,12 +182,12 @@ func TestCodecAwareEncoder_DecodeEvent_WithCodec(t *testing.T) {
 		DataKind:    "test",
 		Metadata:    map[string]interface{}{},
 	}
-	
+
 	event, err := encoder.DecodeEvent(wireEvent)
 	if err != nil {
 		t.Fatalf("DecodeEvent failed: %v", err)
 	}
-	
+
 	if event.ID() != "test-1" {
 		t.Fatalf("Expected ID 'test-1', got %s", event.ID())
 	}
@@ -199,7 +199,7 @@ func TestCodecAwareEncoder_DecodeEvent_WithCodec(t *testing.T) {
 func TestCodecAwareEncoder_DecodeEvent_JSONFallback(t *testing.T) {
 	registry := codec.NewRegistry()
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	// Create a wire event without codec info
 	data, _ := json.Marshal("hello")
 	wireEvent := WireEvent{
@@ -209,12 +209,12 @@ func TestCodecAwareEncoder_DecodeEvent_JSONFallback(t *testing.T) {
 		Data:        data,
 		Metadata:    map[string]interface{}{},
 	}
-	
+
 	event, err := encoder.DecodeEvent(wireEvent)
 	if err != nil {
 		t.Fatalf("DecodeEvent failed: %v", err)
 	}
-	
+
 	if event.Data() != "hello" {
 		t.Fatalf("Expected 'hello', got %v", event.Data())
 	}
@@ -224,32 +224,32 @@ func TestCodecAwareEncoder_RoundTrip(t *testing.T) {
 	registry := codec.NewRegistry()
 	testCodec := &testCodec{kind: "test"}
 	registry.Register(testCodec)
-	
+
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	original := &testEvent{
 		id:          "test-1",
 		eventType:   "TestEvent",
 		aggregateID: "agg-1",
 		data:        "hello",
 		metadata: map[string]interface{}{
-			"kind": "test",
+			"kind":  "test",
 			"other": "metadata",
 		},
 	}
-	
+
 	// Encode
 	wireEvent, err := encoder.EncodeEvent(original)
 	if err != nil {
 		t.Fatalf("EncodeEvent failed: %v", err)
 	}
-	
+
 	// Decode
 	decoded, err := encoder.DecodeEvent(wireEvent)
 	if err != nil {
 		t.Fatalf("DecodeEvent failed: %v", err)
 	}
-	
+
 	// Verify round-trip preserved data correctly
 	if decoded.ID() != original.ID() {
 		t.Fatalf("ID mismatch: expected %s, got %s", original.ID(), decoded.ID())
@@ -271,7 +271,7 @@ func TestCodecAwareEncoder_RoundTrip(t *testing.T) {
 func TestCodecAwareEncoder_EncodeEventWithVersion(t *testing.T) {
 	registry := codec.NewRegistry()
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	event := &testEvent{
 		id:          "test-1",
 		eventType:   "TestEvent",
@@ -279,18 +279,18 @@ func TestCodecAwareEncoder_EncodeEventWithVersion(t *testing.T) {
 		data:        "hello",
 		metadata:    map[string]interface{}{},
 	}
-	
+
 	version := cursor.IntegerCursor{Seq: 42}
 	ev := synckit.EventWithVersion{
 		Event:   event,
 		Version: version,
 	}
-	
+
 	wireEv, err := encoder.EncodeEventWithVersion(ev)
 	if err != nil {
 		t.Fatalf("EncodeEventWithVersion failed: %v", err)
 	}
-	
+
 	if wireEv.Version != "42" {
 		t.Fatalf("Expected version '42', got %s", wireEv.Version)
 	}
@@ -302,7 +302,7 @@ func TestCodecAwareEncoder_EncodeEventWithVersion(t *testing.T) {
 func TestCodecAwareEncoder_DecodeEventWithVersion(t *testing.T) {
 	registry := codec.NewRegistry()
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	data, _ := json.Marshal("hello")
 	wireEv := WireEventWithVersion{
 		Event: WireEvent{
@@ -314,16 +314,16 @@ func TestCodecAwareEncoder_DecodeEventWithVersion(t *testing.T) {
 		},
 		Version: "42",
 	}
-	
+
 	parser := func(ctx context.Context, s string) (synckit.Version, error) {
 		return cursor.IntegerCursor{Seq: 42}, nil
 	}
-	
+
 	ev, err := encoder.DecodeEventWithVersion(context.Background(), parser, wireEv)
 	if err != nil {
 		t.Fatalf("DecodeEventWithVersion failed: %v", err)
 	}
-	
+
 	if ev.Event.ID() != "test-1" {
 		t.Fatalf("Expected ID 'test-1', got %s", ev.Event.ID())
 	}
@@ -337,7 +337,7 @@ func TestCodecKindDetection(t *testing.T) {
 	testCodec := &testCodec{kind: "test"}
 	registry.Register(testCodec)
 	encoder := NewCodecAwareEncoder(registry, true)
-	
+
 	testCases := []struct {
 		name     string
 		metadata map[string]interface{}
@@ -369,7 +369,7 @@ func TestCodecKindDetection(t *testing.T) {
 			expected: "",
 		},
 	}
-	
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			event := &testEvent{
@@ -379,12 +379,12 @@ func TestCodecKindDetection(t *testing.T) {
 				data:        "hello",
 				metadata:    tc.metadata,
 			}
-			
+
 			wireEvent, err := encoder.EncodeEvent(event)
 			if err != nil {
 				t.Fatalf("EncodeEvent failed: %v", err)
 			}
-			
+
 			if wireEvent.DataKind != tc.expected {
 				t.Fatalf("Expected DataKind '%s', got '%s'", tc.expected, wireEvent.DataKind)
 			}
@@ -400,23 +400,23 @@ func TestLegacyConversion(t *testing.T) {
 		Data:        "hello",
 		Metadata:    map[string]interface{}{"test": "value"},
 	}
-	
+
 	// Convert to wire format
 	wireEvent, err := toWireEvent(jsonEvent)
 	if err != nil {
 		t.Fatalf("toWireEvent failed: %v", err)
 	}
-	
+
 	if wireEvent.ID != jsonEvent.ID {
 		t.Fatalf("ID mismatch: expected %s, got %s", jsonEvent.ID, wireEvent.ID)
 	}
-	
+
 	// Convert back to JSON format
 	converted, err := fromWireEvent(wireEvent)
 	if err != nil {
 		t.Fatalf("fromWireEvent failed: %v", err)
 	}
-	
+
 	if converted.ID != jsonEvent.ID {
 		t.Fatalf("ID mismatch: expected %s, got %s", jsonEvent.ID, converted.ID)
 	}

--- a/transport/rabbitmq/config_test.go
+++ b/transport/rabbitmq/config_test.go
@@ -32,22 +32,22 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestConfigValidation(t *testing.T) {
 	tests := []struct {
-		name        string
-		modifyConfig func(*Config)
-		expectError bool
+		name          string
+		modifyConfig  func(*Config)
+		expectError   bool
 		errorContains string
 	}{
 		{
-			name:        "valid default config",
+			name:         "valid default config",
 			modifyConfig: func(c *Config) {},
-			expectError: false,
+			expectError:  false,
 		},
 		{
 			name: "empty URL",
 			modifyConfig: func(c *Config) {
 				c.URL = ""
 			},
-			expectError: true,
+			expectError:   true,
 			errorContains: "URL is required",
 		},
 		{
@@ -55,7 +55,7 @@ func TestConfigValidation(t *testing.T) {
 			modifyConfig: func(c *Config) {
 				c.Exchange = ""
 			},
-			expectError: true,
+			expectError:   true,
 			errorContains: "Exchange name is required",
 		},
 		{
@@ -63,7 +63,7 @@ func TestConfigValidation(t *testing.T) {
 			modifyConfig: func(c *Config) {
 				c.ExchangeType = "invalid"
 			},
-			expectError: true,
+			expectError:   true,
 			errorContains: "invalid exchange type",
 		},
 		{
@@ -71,7 +71,7 @@ func TestConfigValidation(t *testing.T) {
 			modifyConfig: func(c *Config) {
 				c.PrefetchCount = -1
 			},
-			expectError: true,
+			expectError:   true,
 			errorContains: "PrefetchCount cannot be negative",
 		},
 		{
@@ -85,10 +85,10 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "auto-apply defaults for missing values",
 			modifyConfig: func(c *Config) {
-				c.ExchangeType = "" // Should default to "topic"
+				c.ExchangeType = ""   // Should default to "topic"
 				c.ConnectionName = "" // Should default to "go-sync-kit"
-				c.Heartbeat = 0 // Should default to 60s
-				c.PrefetchCount = 0 // Should default to 10
+				c.Heartbeat = 0       // Should default to 60s
+				c.PrefetchCount = 0   // Should default to 10
 			},
 			expectError: false,
 		},
@@ -108,7 +108,7 @@ func TestConfigValidation(t *testing.T) {
 				}
 			} else {
 				assert.NoError(t, err)
-				
+
 				// Verify defaults were applied
 				if cfg.ExchangeType == "" {
 					assert.Equal(t, "topic", cfg.ExchangeType)
@@ -183,7 +183,7 @@ type mockEvent struct {
 	eventType string
 }
 
-func (m *mockEvent) ID() string                        { return "test-id" }
+func (m *mockEvent) ID() string                       { return "test-id" }
 func (m *mockEvent) Type() string                     { return m.eventType }
 func (m *mockEvent) AggregateID() string              { return "test-aggregate" }
 func (m *mockEvent) Data() interface{}                { return nil }

--- a/transport/rabbitmq/integration_test.go
+++ b/transport/rabbitmq/integration_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 )
 
 // MockEvent implements synckit.Event for testing
@@ -24,20 +24,20 @@ type MockEvent struct {
 	metadata    map[string]interface{}
 }
 
-func (e MockEvent) ID() string                            { return e.id }
-func (e MockEvent) Type() string                          { return e.eventType }
-func (e MockEvent) AggregateID() string                   { return e.aggregateID }
-func (e MockEvent) Data() interface{}                     { return e.data }
-func (e MockEvent) Metadata() map[string]interface{}      { return e.metadata }
-func (e MockEvent) MarshalJSON() ([]byte, error)          { return json.Marshal(e.data) }
-func (e *MockEvent) UnmarshalJSON(data []byte) error      { return json.Unmarshal(data, &e.data) }
+func (e MockEvent) ID() string                       { return e.id }
+func (e MockEvent) Type() string                     { return e.eventType }
+func (e MockEvent) AggregateID() string              { return e.aggregateID }
+func (e MockEvent) Data() interface{}                { return e.data }
+func (e MockEvent) Metadata() map[string]interface{} { return e.metadata }
+func (e MockEvent) MarshalJSON() ([]byte, error)     { return json.Marshal(e.data) }
+func (e *MockEvent) UnmarshalJSON(data []byte) error { return json.Unmarshal(data, &e.data) }
 
 // MockVersion implements synckit.Version
 type MockVersion struct {
 	value int64
 }
 
-func (v MockVersion) String() string                  { return fmt.Sprintf("%d", v.value) }
+func (v MockVersion) String() string { return fmt.Sprintf("%d", v.value) }
 func (v MockVersion) Compare(other synckit.Version) int {
 	if otherMock, ok := other.(MockVersion); ok {
 		if v.value < otherMock.value {
@@ -49,7 +49,7 @@ func (v MockVersion) Compare(other synckit.Version) int {
 	}
 	return -1
 }
-func (v MockVersion) IsZero() bool                    { return v.value == 0 }
+func (v MockVersion) IsZero() bool { return v.value == 0 }
 
 // Test configuration
 func getTestConfig() *Config {
@@ -132,9 +132,9 @@ func TestIntegration_PushAndSubscribe(t *testing.T) {
 	// Setup test data
 	events := []synckit.EventWithVersion{
 		{
-			Event:   MockEvent{
-				id:          "event-1", 
-				eventType:   "user.created", 
+			Event: MockEvent{
+				id:          "event-1",
+				eventType:   "user.created",
 				aggregateID: "user-123",
 				data:        map[string]interface{}{"name": "John"},
 				metadata:    map[string]interface{}{"source": "test"},
@@ -142,9 +142,9 @@ func TestIntegration_PushAndSubscribe(t *testing.T) {
 			Version: MockVersion{value: 1},
 		},
 		{
-			Event:   MockEvent{
-				id:          "event-2", 
-				eventType:   "user.updated", 
+			Event: MockEvent{
+				id:          "event-2",
+				eventType:   "user.updated",
 				aggregateID: "user-123",
 				data:        map[string]interface{}{"name": "Jane"},
 				metadata:    map[string]interface{}{"source": "test"},
@@ -163,7 +163,7 @@ func TestIntegration_PushAndSubscribe(t *testing.T) {
 		receivedMu.Lock()
 		allReceived = append(allReceived, events...)
 		receivedMu.Unlock()
-		
+
 		receivedEvents <- events
 		return nil
 	}
@@ -198,7 +198,7 @@ func TestIntegration_PushAndSubscribe(t *testing.T) {
 	defer receivedMu.Unlock()
 
 	assert.Equal(t, len(events), len(allReceived))
-	
+
 	// Create maps for easy comparison (order may vary)
 	expectedMap := make(map[string]synckit.EventWithVersion)
 	for _, event := range events {
@@ -233,13 +233,13 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 	// Test push without connection
 	events := []synckit.EventWithVersion{
 		{Event: MockEvent{
-			id:          "test", 
+			id:          "test",
 			eventType:   "test",
-			aggregateID: "agg-test", 
+			aggregateID: "agg-test",
 			data:        map[string]interface{}{},
 		}},
 	}
-	
+
 	err := transport.Push(ctx, events)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not connected")
@@ -298,7 +298,7 @@ func TestIntegration_MultiplePublishers(t *testing.T) {
 	// Create multiple publishers
 	const numPublishers = 3
 	const eventsPerPublisher = 5
-	
+
 	var publisherWg sync.WaitGroup
 	publisherWg.Add(numPublishers)
 
@@ -371,7 +371,7 @@ func TestIntegration_MultiplePublishers(t *testing.T) {
 	}
 
 	for i := 0; i < numPublishers; i++ {
-		assert.Equal(t, eventsPerPublisher, publisherCounts[i], 
+		assert.Equal(t, eventsPerPublisher, publisherCounts[i],
 			"Publisher %d should have %d events", i, eventsPerPublisher)
 	}
 }
@@ -443,13 +443,13 @@ func TestIntegration_HandlerError(t *testing.T) {
 	case received := <-successEvents:
 		assert.Len(t, received, 1)
 		assert.Equal(t, "error-test", received[0].Event.ID())
-		
+
 		// Verify multiple attempts were made
 		mu.Lock()
 		finalAttemptCount := attemptCount
 		mu.Unlock()
 		assert.GreaterOrEqual(t, finalAttemptCount, 3, "Handler should have been called at least 3 times")
-		
+
 	case <-timeout:
 		mu.Lock()
 		finalAttemptCount := attemptCount

--- a/transport/rabbitmq/transport.go
+++ b/transport/rabbitmq/transport.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
+	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 )
 
 // Transport implements synckit.Transport using RabbitMQ for reliable messaging.
@@ -468,7 +468,7 @@ type SimpleVersion struct {
 	value string
 }
 
-func (v SimpleVersion) String() string                  { return v.value }
+func (v SimpleVersion) String() string { return v.value }
 func (v SimpleVersion) Compare(other synckit.Version) int {
 	if otherSimple, ok := other.(SimpleVersion); ok {
 		if v.value < otherSimple.value {

--- a/transport/rabbitmq/types.go
+++ b/transport/rabbitmq/types.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Config defines the RabbitMQ transport configuration.
@@ -41,9 +41,9 @@ type Config struct {
 	DeadLetterQueue string
 
 	// Observability
-	Tracer        SyncKitTracer
-	Metrics       MetricsCollector
-	Logger        *slog.Logger
+	Tracer  SyncKitTracer
+	Metrics MetricsCollector
+	Logger  *slog.Logger
 }
 
 // DefaultConfig returns a RabbitMQ config with sensible defaults.
@@ -88,7 +88,7 @@ func (c *Config) Validate() error {
 		}
 	}
 	if !valid {
-		return fmt.Errorf("invalid exchange type %s, must be one of: %s", 
+		return fmt.Errorf("invalid exchange type %s, must be one of: %s",
 			c.ExchangeType, strings.Join(validTypes, ", "))
 	}
 

--- a/transport/sse/client.go
+++ b/transport/sse/client.go
@@ -12,12 +12,11 @@ import (
 	"strings"
 	"time"
 
-	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 	"github.com/c0deZ3R0/go-sync-kit/cursor"
 	kiterr "github.com/c0deZ3R0/go-sync-kit/errors"
 	"github.com/c0deZ3R0/go-sync-kit/logging"
+	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 )
-
 
 type Client struct {
 	BaseURL string
@@ -177,7 +176,7 @@ func (c *Client) consumeStream(ctx context.Context, body io.ReadCloser, handler 
 
 		var payload struct {
 			Events     []JSONEventWithVersion `json:"events"`
-			NextCursor cursor.WireCursor       `json:"next_cursor"`
+			NextCursor cursor.WireCursor      `json:"next_cursor"`
 		}
 
 		if err := json.Unmarshal(bytes.TrimPrefix(line, []byte("data: ")), &payload); err != nil {
@@ -224,18 +223,18 @@ func (c *Client) consumeStream(ctx context.Context, body io.ReadCloser, handler 
 }
 
 // Implement other Transport methods as passthroughs or unimplemented if Subscribe-only for MVP.
-func (c *Client) Push(ctx context.Context, _ []synckit.EventWithVersion) error { 
-	return kiterr.E(kiterr.Op("sse.Push"), kiterr.Component("transport/sse"), kiterr.KindMethodNotAllowed, "not implemented") 
+func (c *Client) Push(ctx context.Context, _ []synckit.EventWithVersion) error {
+	return kiterr.E(kiterr.Op("sse.Push"), kiterr.Component("transport/sse"), kiterr.KindMethodNotAllowed, "not implemented")
 }
 
-func (c *Client) Pull(ctx context.Context, _ synckit.Version) ([]synckit.EventWithVersion, error) { 
-	return nil, kiterr.E(kiterr.Op("sse.Pull"), kiterr.Component("transport/sse"), kiterr.KindMethodNotAllowed, "not implemented") 
+func (c *Client) Pull(ctx context.Context, _ synckit.Version) ([]synckit.EventWithVersion, error) {
+	return nil, kiterr.E(kiterr.Op("sse.Pull"), kiterr.Component("transport/sse"), kiterr.KindMethodNotAllowed, "not implemented")
 }
 
 func (c *Client) GetLatestVersion(ctx context.Context) (synckit.Version, error) {
 	return nil, kiterr.E(kiterr.Op("sse.GetLatestVersion"), kiterr.Component("transport/sse"), kiterr.KindMethodNotAllowed, "not implemented")
 }
 
-func (c *Client) Close() error { 
-	return nil 
+func (c *Client) Close() error {
+	return nil
 }

--- a/transport/sse/client_test.go
+++ b/transport/sse/client_test.go
@@ -83,7 +83,7 @@ func TestSubscribe_ServerReconnection(t *testing.T) {
 		// Send a test event
 		eventData := struct {
 			Events     []JSONEventWithVersion `json:"events"`
-			NextCursor cursor.WireCursor       `json:"next_cursor"`
+			NextCursor cursor.WireCursor      `json:"next_cursor"`
 		}{
 			Events: []JSONEventWithVersion{
 				{
@@ -216,13 +216,13 @@ func TestSubscribe_ExponentialBackoff(t *testing.T) {
 func TestSubscribe_SuccessfulConnection(t *testing.T) {
 	connectionCount := 0
 	mu := sync.Mutex{}
-	
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		connectionCount++
 		currConnection := connectionCount
 		mu.Unlock()
-		
+
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
@@ -233,7 +233,7 @@ func TestSubscribe_SuccessfulConnection(t *testing.T) {
 			for i := 1; i <= 3; i++ {
 				eventData := struct {
 					Events     []JSONEventWithVersion `json:"events"`
-					NextCursor cursor.WireCursor       `json:"next_cursor"`
+					NextCursor cursor.WireCursor      `json:"next_cursor"`
 				}{
 					Events: []JSONEventWithVersion{
 						{
@@ -251,7 +251,7 @@ func TestSubscribe_SuccessfulConnection(t *testing.T) {
 
 				jsonData, _ := json.Marshal(eventData)
 				fmt.Fprintf(w, "data: %s\n\n", jsonData)
-				
+
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()
 				}
@@ -336,7 +336,7 @@ func TestSubscribe_HandlerError(t *testing.T) {
 
 		eventData := struct {
 			Events     []JSONEventWithVersion `json:"events"`
-			NextCursor cursor.WireCursor       `json:"next_cursor"`
+			NextCursor cursor.WireCursor      `json:"next_cursor"`
 		}{
 			Events: []JSONEventWithVersion{
 				{
@@ -385,13 +385,13 @@ func TestSubscribe_HandlerError(t *testing.T) {
 func TestSubscribe_InvalidJSON(t *testing.T) {
 	connectionCount := 0
 	mu := sync.Mutex{}
-	
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		connectionCount++
 		currConnection := connectionCount
 		mu.Unlock()
-		
+
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 
@@ -399,17 +399,17 @@ func TestSubscribe_InvalidJSON(t *testing.T) {
 		if currConnection == 1 {
 			// Send invalid JSON
 			fmt.Fprintf(w, "data: {invalid json}\n\n")
-			
+
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
-			
+
 			time.Sleep(50 * time.Millisecond)
-			
+
 			// Then send valid JSON
 			eventData := struct {
 				Events     []JSONEventWithVersion `json:"events"`
-				NextCursor cursor.WireCursor       `json:"next_cursor"`
+				NextCursor cursor.WireCursor      `json:"next_cursor"`
 			}{
 				Events: []JSONEventWithVersion{
 					{
@@ -423,15 +423,15 @@ func TestSubscribe_InvalidJSON(t *testing.T) {
 					},
 				},
 			}
-			
+
 			jsonData, _ := json.Marshal(eventData)
 			fmt.Fprintf(w, "data: %s\n\n", jsonData)
-			
+
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
 		}
-		
+
 		time.Sleep(100 * time.Millisecond)
 	}))
 	defer server.Close()
@@ -489,7 +489,7 @@ func TestSubscribe_ReconnectAfterStreamEnd(t *testing.T) {
 		// Send an event with connection number
 		eventData := struct {
 			Events     []JSONEventWithVersion `json:"events"`
-			NextCursor cursor.WireCursor       `json:"next_cursor"`
+			NextCursor cursor.WireCursor      `json:"next_cursor"`
 		}{
 			Events: []JSONEventWithVersion{
 				{

--- a/transport/sse/example_test.go
+++ b/transport/sse/example_test.go
@@ -9,24 +9,24 @@ import (
 	"testing"
 	"time"
 
-	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 	"github.com/c0deZ3R0/go-sync-kit/cursor"
+	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 )
 
 // ExampleEvent implements synckit.Event for testing
 type ExampleEvent struct {
-	IDValue         string                 `json:"id"`
-	TypeValue       string                 `json:"type"`
-	AggregateIDValue string                `json:"aggregate_id"`
-	DataValue       interface{}            `json:"data"`
-	MetadataValue   map[string]interface{} `json:"metadata"`
+	IDValue          string                 `json:"id"`
+	TypeValue        string                 `json:"type"`
+	AggregateIDValue string                 `json:"aggregate_id"`
+	DataValue        interface{}            `json:"data"`
+	MetadataValue    map[string]interface{} `json:"metadata"`
 }
 
-func (e ExampleEvent) ID() string                            { return e.IDValue }
-func (e ExampleEvent) Type() string                          { return e.TypeValue }
-func (e ExampleEvent) AggregateID() string                   { return e.AggregateIDValue }
-func (e ExampleEvent) Data() interface{}                     { return e.DataValue }
-func (e ExampleEvent) Metadata() map[string]interface{}      { return e.MetadataValue }
+func (e ExampleEvent) ID() string                       { return e.IDValue }
+func (e ExampleEvent) Type() string                     { return e.TypeValue }
+func (e ExampleEvent) AggregateID() string              { return e.AggregateIDValue }
+func (e ExampleEvent) Data() interface{}                { return e.DataValue }
+func (e ExampleEvent) Metadata() map[string]interface{} { return e.MetadataValue }
 
 // MockEventStore implements synckit.EventStore for testing
 type MockEventStore struct {
@@ -47,7 +47,7 @@ func (m *MockEventStore) Load(ctx context.Context, since synckit.Version) ([]syn
 			sinceSeq = ic.Seq
 		}
 	}
-	
+
 	for i, ev := range m.events {
 		if ic, ok := ev.Version.(cursor.IntegerCursor); ok && ic.Seq > sinceSeq {
 			result = append(result, ev)
@@ -63,7 +63,7 @@ func (m *MockEventStore) LoadByAggregate(ctx context.Context, aggregateID string
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var result []synckit.EventWithVersion
 	for _, ev := range events {
 		if ev.Event.AggregateID() == aggregateID {
@@ -92,37 +92,37 @@ func (m *MockEventStore) Close() error {
 func ExampleTransport() {
 	// Initialize cursor codecs
 	cursor.InitDefaultCodecs()
-	
+
 	// Create mock store with some test events
 	store := &MockEventStore{}
 	store.Store(context.Background(), ExampleEvent{
-		IDValue:         "event-1",
-		TypeValue:       "UserCreated",
+		IDValue:          "event-1",
+		TypeValue:        "UserCreated",
 		AggregateIDValue: "user-123",
-		DataValue:       map[string]interface{}{"name": "John Doe"},
+		DataValue:        map[string]interface{}{"name": "John Doe"},
 	}, cursor.NewInteger(1))
-	
+
 	store.Store(context.Background(), ExampleEvent{
-		IDValue:         "event-2", 
-		TypeValue:       "UserUpdated",
+		IDValue:          "event-2",
+		TypeValue:        "UserUpdated",
 		AggregateIDValue: "user-123",
-		DataValue:       map[string]interface{}{"name": "John Smith"},
+		DataValue:        map[string]interface{}{"name": "John Smith"},
 	}, cursor.NewInteger(2))
 
 	// Create SSE server
 	server := NewServer(store, slog.Default())
-	
+
 	// Create test HTTP server
 	testServer := httptest.NewServer(server.Handler())
 	defer testServer.Close()
-	
+
 	// Create SSE client
 	client := NewClient(testServer.URL, nil)
-	
+
 	// Subscribe to events
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	
+
 	eventCount := 0
 	err := client.Subscribe(ctx, func(events []synckit.EventWithVersion) error {
 		for _, ev := range events {
@@ -131,13 +131,13 @@ func ExampleTransport() {
 		}
 		return nil
 	})
-	
+
 	if err != nil && !strings.Contains(err.Error(), "context deadline exceeded") && err.Error() != "context canceled" {
 		fmt.Printf("Subscribe error: %v\n", err)
 	}
-	
+
 	fmt.Printf("Total events received: %d\n", eventCount)
-	// Output: 
+	// Output:
 	// Received event: UserCreated - event-1
 	// Received event: UserUpdated - event-2
 	// Total events received: 2
@@ -146,28 +146,28 @@ func ExampleTransport() {
 func TestSSEBasicIntegration(t *testing.T) {
 	// Initialize cursor codecs
 	cursor.InitDefaultCodecs()
-	
+
 	// Create mock store
 	store := &MockEventStore{}
-	
+
 	// Create SSE server
 	server := NewServer(store, slog.Default())
-	
+
 	// Test that server can be created
 	if server == nil {
 		t.Fatal("Failed to create SSE server")
 	}
-	
+
 	if server.BatchSize != 100 {
 		t.Errorf("Expected default batch size 100, got %d", server.BatchSize)
 	}
-	
+
 	// Test client creation
 	client := NewClient("http://localhost:8080", nil)
 	if client == nil {
 		t.Fatal("Failed to create SSE client")
 	}
-	
+
 	if client.BaseURL != "http://localhost:8080" {
 		t.Errorf("Expected BaseURL 'http://localhost:8080', got '%s'", client.BaseURL)
 	}

--- a/transport/sse/server.go
+++ b/transport/sse/server.go
@@ -1,6 +1,6 @@
 package sse
 
-	import (
+import (
 	"context"
 	"encoding/json"
 	"fmt"
@@ -8,11 +8,10 @@ package sse
 	"net/http"
 	"time"
 
-	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 	"github.com/c0deZ3R0/go-sync-kit/cursor"
 	"github.com/c0deZ3R0/go-sync-kit/logging"
+	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 )
-
 
 type Server struct {
 	Store     synckit.EventStore
@@ -108,19 +107,19 @@ func (s *Server) Handler() http.Handler {
 				continue
 			}
 
-		// Convert events to JSON serializable format
-		jsonEvents := make([]JSONEventWithVersion, len(events))
-		for i, ev := range events {
-			jsonEvents[i] = toJSONEventWithVersion(ev)
-		}
+			// Convert events to JSON serializable format
+			jsonEvents := make([]JSONEventWithVersion, len(events))
+			for i, ev := range events {
+				jsonEvents[i] = toJSONEventWithVersion(ev)
+			}
 
-		payload := struct {
-			Events     []JSONEventWithVersion `json:"events"`
-			NextCursor cursor.WireCursor       `json:"next_cursor"`
-		}{
-			Events:     jsonEvents,
-			NextCursor: cursor.MustMarshalWire(nextCur),
-		}
+			payload := struct {
+				Events     []JSONEventWithVersion `json:"events"`
+				NextCursor cursor.WireCursor      `json:"next_cursor"`
+			}{
+				Events:     jsonEvents,
+				NextCursor: cursor.MustMarshalWire(nextCur),
+			}
 			b, _ := json.Marshal(payload)
 			s.Logger.Debug("Sending events to SSE client",
 				slog.Int("event_count", len(events)),
@@ -138,7 +137,7 @@ func (s *Server) Handler() http.Handler {
 func loadNext(ctx context.Context, store synckit.EventStore, cur cursor.Cursor, batch int) ([]synckit.EventWithVersion, cursor.Cursor, error) {
 	// For initial MVP, call Load since version or a cursor-aware LoadNext if available.
 	// Return events and a new cursor (e.g., last seen version).
-	
+
 	// Convert cursor to version for store.Load
 	var sinceVersion synckit.Version
 	if cur != nil {
@@ -149,7 +148,7 @@ func loadNext(ctx context.Context, store synckit.EventStore, cur cursor.Cursor, 
 			sinceVersion = vc
 		}
 	}
-	
+
 	evs, err := store.Load(ctx, sinceVersion)
 	if err != nil {
 		return nil, nil, err

--- a/transport/sse/types.go
+++ b/transport/sse/types.go
@@ -1,8 +1,8 @@
 package sse
 
 import (
-	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 	"github.com/c0deZ3R0/go-sync-kit/cursor"
+	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
 )
 
 // JSONEvent is a JSON-serializable representation of an Event

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -9,43 +9,43 @@ import (
 
 // Common transport errors
 var (
-	ErrTransportClosed    = errors.New("transport is closed")
-	ErrConnectionFailed   = errors.New("connection failed")
-	ErrInvalidPeer        = errors.New("invalid peer")
-	ErrTransportTimeout   = errors.New("transport operation timeout")
-	ErrPeerNotFound       = errors.New("peer not found")
+	ErrTransportClosed  = errors.New("transport is closed")
+	ErrConnectionFailed = errors.New("connection failed")
+	ErrInvalidPeer      = errors.New("invalid peer")
+	ErrTransportTimeout = errors.New("transport operation timeout")
+	ErrPeerNotFound     = errors.New("peer not found")
 )
 
 // Transport defines the interface for transport layers.
 type Transport interface {
 	// Connect establishes a connection to a peer.
 	Connect(ctx context.Context, peer string) error
-	
+
 	// Disconnect closes the connection to a peer.
 	Disconnect(ctx context.Context, peer string) error
-	
+
 	// Send sends data to a peer.
 	Send(ctx context.Context, peer string, data []byte) error
-	
+
 	// Receive receives data from any connected peer.
 	Receive(ctx context.Context) (peer string, data []byte, err error)
-	
+
 	// IsConnected checks if connected to a peer.
 	IsConnected(peer string) bool
-	
+
 	// GetConnectedPeers returns a list of connected peers.
 	GetConnectedPeers() []string
-	
+
 	// Close closes the transport layer.
 	Close() error
 }
 
 // MockTransport is a simple mock transport implementation for testing.
 type MockTransport struct {
-	mu          sync.RWMutex
-	peers       map[string]bool
+	mu           sync.RWMutex
+	peers        map[string]bool
 	messageQueue []Message
-	closed      bool
+	closed       bool
 }
 
 // Message represents a message in the transport layer.
@@ -58,7 +58,7 @@ type Message struct {
 // NewMockTransport creates a new mock transport.
 func NewMockTransport() *MockTransport {
 	return &MockTransport{
-		peers:       make(map[string]bool),
+		peers:        make(map[string]bool),
 		messageQueue: make([]Message, 0),
 	}
 }
@@ -67,20 +67,20 @@ func (m *MockTransport) Connect(ctx context.Context, peer string) error {
 	if peer == "" {
 		return ErrInvalidPeer
 	}
-	
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if m.closed {
 		return ErrTransportClosed
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	
+
 	m.peers[peer] = true
 	return nil
 }
@@ -89,20 +89,20 @@ func (m *MockTransport) Disconnect(ctx context.Context, peer string) error {
 	if peer == "" {
 		return ErrInvalidPeer
 	}
-	
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if m.closed {
 		return ErrTransportClosed
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	
+
 	delete(m.peers, peer)
 	return nil
 }
@@ -111,24 +111,24 @@ func (m *MockTransport) Send(ctx context.Context, peer string, data []byte) erro
 	if peer == "" {
 		return ErrInvalidPeer
 	}
-	
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if m.closed {
 		return ErrTransportClosed
 	}
-	
+
 	if !m.peers[peer] {
 		return ErrPeerNotFound
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
-	
+
 	// In a mock transport, we just queue the message
 	message := Message{
 		Peer:      peer,
@@ -142,24 +142,24 @@ func (m *MockTransport) Send(ctx context.Context, peer string, data []byte) erro
 func (m *MockTransport) Receive(ctx context.Context) (peer string, data []byte, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	if m.closed {
 		return "", nil, ErrTransportClosed
 	}
-	
+
 	select {
 	case <-ctx.Done():
 		return "", nil, ctx.Err()
 	default:
 	}
-	
+
 	// Return the first message in queue if any
 	if len(m.messageQueue) > 0 {
 		message := m.messageQueue[0]
 		m.messageQueue = m.messageQueue[1:]
 		return message.Peer, message.Data, nil
 	}
-	
+
 	// No messages available
 	return "", nil, nil
 }
@@ -167,22 +167,22 @@ func (m *MockTransport) Receive(ctx context.Context) (peer string, data []byte, 
 func (m *MockTransport) IsConnected(peer string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	if m.closed {
 		return false
 	}
-	
+
 	return m.peers[peer]
 }
 
 func (m *MockTransport) GetConnectedPeers() []string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	if m.closed {
 		return []string{}
 	}
-	
+
 	peers := make([]string, 0, len(m.peers))
 	for peer := range m.peers {
 		peers = append(peers, peer)
@@ -193,7 +193,7 @@ func (m *MockTransport) GetConnectedPeers() []string {
 func (m *MockTransport) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	m.closed = true
 	m.peers = nil
 	m.messageQueue = nil

--- a/version/benchmark_test.go
+++ b/version/benchmark_test.go
@@ -19,7 +19,7 @@ func BenchmarkVectorClockOperations(b *testing.B) {
 		{"Serialization", benchmarkSerialization},
 		{"Deserialization", benchmarkDeserialization},
 	}
-	
+
 	for _, benchmark := range benchmarks {
 		b.Run(benchmark.name, benchmark.fn)
 	}
@@ -27,16 +27,16 @@ func BenchmarkVectorClockOperations(b *testing.B) {
 
 func benchmarkIncrement(b *testing.B) {
 	clockSizes := []int{1, 5, 10, 25, 50, 100}
-	
+
 	for _, size := range clockSizes {
 		b.Run(fmt.Sprintf("Size_%d", size), func(b *testing.B) {
 			clock := NewVectorClock()
-			
+
 			// Pre-populate with size-1 nodes to test increment on existing
 			for i := 0; i < size-1; i++ {
 				clock.Increment(fmt.Sprintf("node-%d", i))
 			}
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				// Alternate between existing and new nodes
@@ -49,8 +49,8 @@ func benchmarkIncrement(b *testing.B) {
 
 func benchmarkCompare(b *testing.B) {
 	scenarios := []struct {
-		name     string
-		setupFn  func() (*VectorClock, *VectorClock)
+		name    string
+		setupFn func() (*VectorClock, *VectorClock)
 	}{
 		{"Identical", setupIdenticalClocks},
 		{"HappenedBefore", setupHappenedBeforeClocks},
@@ -58,11 +58,11 @@ func benchmarkCompare(b *testing.B) {
 		{"Large", setupLargeClocks},
 		{"Sparse", setupSparseClocks},
 	}
-	
+
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, func(b *testing.B) {
 			vc1, vc2 := scenario.setupFn()
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				vc1.Compare(vc2)
@@ -82,11 +82,11 @@ func benchmarkMerge(b *testing.B) {
 		{"DisjointClocks", setupDisjointMergeClocks},
 		{"OverlappingClocks", setupOverlappingMergeClocks},
 	}
-	
+
 	for _, scenario := range mergeScenarios {
 		b.Run(scenario.name, func(b *testing.B) {
 			originalVc1, originalVc2 := scenario.setupFn()
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				// Clone to avoid modifying the original clocks
@@ -99,11 +99,11 @@ func benchmarkMerge(b *testing.B) {
 
 func benchmarkClone(b *testing.B) {
 	clockSizes := []int{1, 10, 50, 100, 250}
-	
+
 	for _, size := range clockSizes {
 		b.Run(fmt.Sprintf("Size_%d", size), func(b *testing.B) {
 			clock := createClockWithSize(size)
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = clock.Clone()
@@ -114,11 +114,11 @@ func benchmarkClone(b *testing.B) {
 
 func benchmarkSerialization(b *testing.B) {
 	clockSizes := []int{1, 10, 50, 100, 250}
-	
+
 	for _, size := range clockSizes {
 		b.Run(fmt.Sprintf("Size_%d", size), func(b *testing.B) {
 			clock := createClockWithSize(size)
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_ = clock.String()
@@ -129,12 +129,12 @@ func benchmarkSerialization(b *testing.B) {
 
 func benchmarkDeserialization(b *testing.B) {
 	clockSizes := []int{1, 10, 50, 100, 250}
-	
+
 	for _, size := range clockSizes {
 		b.Run(fmt.Sprintf("Size_%d", size), func(b *testing.B) {
 			clock := createClockWithSize(size)
 			serialized := clock.String()
-			
+
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, err := NewVectorClockFromString(serialized)
@@ -157,7 +157,7 @@ func BenchmarkVectorClockConcurrentOperations(b *testing.B) {
 		{"ConcurrentCompare", benchmarkConcurrentCompare},
 		{"ConcurrentMerge", benchmarkConcurrentMerge},
 	}
-	
+
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, scenario.fn)
 	}
@@ -166,15 +166,15 @@ func BenchmarkVectorClockConcurrentOperations(b *testing.B) {
 func benchmarkConcurrentIncrement(b *testing.B) {
 	const numGoroutines = 10
 	const clockSize = 50
-	
+
 	b.RunParallel(func(pb *testing.PB) {
 		clock := createClockWithSize(clockSize)
 		nodeCounter := 0
-		
+
 		for pb.Next() {
 			nodeID := fmt.Sprintf("concurrent-node-%d", nodeCounter%clockSize)
 			nodeCounter++
-			
+
 			// Each goroutine increments different nodes
 			clock.Increment(nodeID)
 		}
@@ -184,12 +184,12 @@ func benchmarkConcurrentIncrement(b *testing.B) {
 func benchmarkConcurrentCompare(b *testing.B) {
 	clock1 := createClockWithSize(100)
 	clock2 := createClockWithSize(100)
-	
+
 	// Make clock2 happen after clock1
 	for i := 0; i < 50; i++ {
 		clock2.Increment(fmt.Sprintf("node-%d", i))
 	}
-	
+
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			clock1.Compare(clock2)
@@ -199,10 +199,10 @@ func benchmarkConcurrentCompare(b *testing.B) {
 
 func benchmarkConcurrentMerge(b *testing.B) {
 	baseClock := createClockWithSize(50)
-	
+
 	b.RunParallel(func(pb *testing.PB) {
 		mergeClock := createClockWithSize(25)
-		
+
 		for pb.Next() {
 			clock := baseClock.Clone()
 			clock.Merge(mergeClock)
@@ -220,7 +220,7 @@ func BenchmarkVectorClockRealWorldScenarios(b *testing.B) {
 		{"EventSourcing", benchmarkEventSourcingScenario},
 		{"CRDTOperations", benchmarkCRDTOperations},
 	}
-	
+
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, scenario.fn)
 	}
@@ -230,19 +230,19 @@ func benchmarkDistributedSystemScenario(b *testing.B) {
 	// Simulate a distributed system with 5 nodes
 	const numNodes = 5
 	nodes := make([]*VectorClock, numNodes)
-	
+
 	for i := 0; i < numNodes; i++ {
 		nodes[i] = NewVectorClock()
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		nodeIndex := i % numNodes
 		nodeID := fmt.Sprintf("node-%d", nodeIndex)
-		
+
 		// Each node creates an event
 		nodes[nodeIndex].Increment(nodeID)
-		
+
 		// Periodically sync with other nodes
 		if i%10 == 0 {
 			otherNodeIndex := (nodeIndex + 1) % numNodes
@@ -255,16 +255,16 @@ func benchmarkEventSourcingScenario(b *testing.B) {
 	// Simulate an event sourcing scenario where we track causality
 	aggregateClock := NewVectorClock()
 	eventClocks := make([]*VectorClock, 0, b.N)
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Create a new event with current aggregate state
 		eventClock := aggregateClock.Clone()
 		eventClock.Increment(fmt.Sprintf("aggregate-%d", i%10))
-		
+
 		// Store the event clock
 		eventClocks = append(eventClocks, eventClock)
-		
+
 		// Update aggregate clock
 		aggregateClock.Merge(eventClock)
 	}
@@ -274,19 +274,19 @@ func benchmarkCRDTOperations(b *testing.B) {
 	// Simulate CRDT operations where we need to detect concurrent updates
 	const numReplicas = 3
 	replicas := make([]*VectorClock, numReplicas)
-	
+
 	for i := 0; i < numReplicas; i++ {
 		replicas[i] = NewVectorClock()
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		replicaIndex := i % numReplicas
 		replicaID := fmt.Sprintf("replica-%d", replicaIndex)
-		
+
 		// Each replica performs an operation
 		replicas[replicaIndex].Increment(replicaID)
-		
+
 		// Check for conflicts with other replicas
 		if i%5 == 0 {
 			for j := 0; j < numReplicas; j++ {
@@ -342,12 +342,12 @@ func setupConcurrentClocks() (*VectorClock, *VectorClock) {
 func setupLargeClocks() (*VectorClock, *VectorClock) {
 	clock1 := createClockWithSize(100)
 	clock2 := createClockWithSize(100)
-	
+
 	// Make them have some overlap but also some differences
 	for i := 0; i < 50; i++ {
 		clock2.Increment(fmt.Sprintf("node-%d", i))
 	}
-	
+
 	return clock1, clock2
 }
 
@@ -385,20 +385,20 @@ func setupLargeMergeClocks() (*VectorClock, *VectorClock) {
 func setupDisjointMergeClocks() (*VectorClock, *VectorClock) {
 	clock1 := NewVectorClock()
 	clock2 := NewVectorClock()
-	
+
 	// Completely disjoint node sets
 	for i := 0; i < 10; i++ {
 		clock1.Increment(fmt.Sprintf("set-a-node-%d", i))
 		clock2.Increment(fmt.Sprintf("set-b-node-%d", i))
 	}
-	
+
 	return clock1, clock2
 }
 
 func setupOverlappingMergeClocks() (*VectorClock, *VectorClock) {
 	clock1 := NewVectorClock()
 	clock2 := NewVectorClock()
-	
+
 	// Overlapping node sets
 	for i := 0; i < 15; i++ {
 		clock1.Increment(fmt.Sprintf("node-%d", i))
@@ -406,7 +406,7 @@ func setupOverlappingMergeClocks() (*VectorClock, *VectorClock) {
 	for i := 5; i < 20; i++ {
 		clock2.Increment(fmt.Sprintf("node-%d", i))
 	}
-	
+
 	return clock1, clock2
 }
 

--- a/version/store_decorator.go
+++ b/version/store_decorator.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/c0deZ3R0/go-sync-kit/cursor"
 	"github.com/c0deZ3R0/go-sync-kit/logging"
-	"github.com/c0deZ3R0/go-sync-kit/synckit/types"
 	synckit "github.com/c0deZ3R0/go-sync-kit/synckit"
+	"github.com/c0deZ3R0/go-sync-kit/synckit/types"
 )
 
 // VersionManager defines the interface for managing version state.


### PR DESCRIPTION
## Overview
Local developer tooling and quality-of-life improvements, plus a small race fix and safer metrics API.

## Changes
- Taskfile.yml with common targets: test, race, cover, plus test-no-pg and race-no-pg
- Local Git hooks:
  - pre-commit: gofmt check, go vet, go test
  - pre-push: go test -race
- Windows helper scripts: scripts/test-no-pg.ps1, scripts/race-no-pg.ps1, scripts/format.ps1
- Fix: eliminate data race in synckit/realtime by locking stop-channel access and atomically tracking reconnect attempts
- Refactor: statemachine TimeoutMetrics to a tracker + snapshot to avoid copying a mutex
- Tests: Postgres-backed tests are opt-in (set POSTGRES_TEST=1 to enable)

## Developer UX
- task: vet + unit tests
- task test-no-pg: run tests excluding storage/postgres
- task race-no-pg: run -race excluding storage/postgres
- task cover: coverage summary

## Testing
- test-no-pg: passing
- race-no-pg: passing
- Full suite passes when POSTGRES_TEST=1 and a local DB is available

## Notes
- Local-only workflow; no CI required
- See Taskfile.yml for available commands
