### PR TITLE
docs: add missing READMEs to example directories

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,13 @@ Progressive examples from beginner to advanced. Start with [quickstart](quicksta
 
 ## 🎯 Quick Start
 
-### [quickstart/](quickstart)
-Minimal runnable example showing custom events, local storage, and sync with SyncNode.  
+### [quickstart/local-only/](quickstart/local-only)
+Simplest possible setup with in-memory store and null transport. No network needed.  
 **Topics:** Event interface, memstore, null transport, basic sync flow
+
+### [quickstart/http-client/](quickstart/http-client)
+Minimal HTTP client that syncs with a server. Perfect first step after local-only.  
+**Topics:** HTTP transport client, basic network sync, client setup
 
 ---
 
@@ -19,12 +23,17 @@ Production-ready HTTP server with SQLite storage, graceful shutdown, and observa
 **Topics:** HTTP transport, SQLite, server setup, production patterns
 
 ### [http_client/](http_client)
-HTTP client connecting to sync server, demonstrating remote synchronization.  
+Standalone HTTP client example connecting to sync server.  
 **Topics:** HTTP transport client, remote sync, connection management
+
+See [http_client/README.md](http_client/README.md) for run commands.
 
 ### [http_enterprise/](http_enterprise)
 Enterprise features: multitenancy, authentication, filtering, idempotency keys.  
 **Topics:** Bearer auth, tenant isolation, advanced filtering, middleware
+
+- [http_enterprise/server/](http_enterprise/server) - Production-style server with auth
+- [http_enterprise/client/](http_enterprise/client) - Client with token auth and signing
 
 ### [HTTP_EXAMPLES.md](HTTP_EXAMPLES.md)
 Comprehensive HTTP transport guide with SSE (Server-Sent Events) for real-time push.
@@ -48,6 +57,14 @@ Custom event creation, storage with versioning, event retrieval patterns.
 ### [intermediate/04-conflict-resolution/](intermediate/04-conflict-resolution)
 Conflict detection and resolution strategies (LWW, FWW, custom resolvers).  
 **Topics:** ConflictResolver interface, deterministic merge, conflict patterns
+
+### [intermediate/05-realtime-autosync/](intermediate/05-realtime-autosync)
+Timers, background sync, and graceful shutdown patterns.  
+**Topics:** StartAutoSync, StopAutoSync, signal handling, context cancellation
+
+### [intermediate/06-custom-events-filters/](intermediate/06-custom-events-filters)
+Selective sync by event type and metadata filtering.  
+**Topics:** Event filtering, selective sync, custom predicates, bandwidth optimization
 
 ### [intermediate/07-structured-logging/](intermediate/07-structured-logging)
 Integrating structured logging (slog) for production observability.  

--- a/examples/http_client/README.md
+++ b/examples/http_client/README.md
@@ -1,0 +1,25 @@
+# HTTP Client
+
+Minimal client that syncs against a server at `http://localhost:8080/sync`.
+
+## Run
+
+```bash
+cd examples/http_client
+go run .
+```
+
+**Tip**: Start the simple server in another terminal first:
+
+```bash
+cd examples/http_server
+go run main.go
+```
+
+## What It Does
+
+- Connects to HTTP sync endpoint
+- Pushes/pulls events via HTTP transport
+- Demonstrates basic client-server sync pattern
+
+See also: [HTTP Server](../http_server/README.md), [HTTP Examples](../HTTP_EXAMPLES.md)

--- a/examples/http_enterprise/client/README.md
+++ b/examples/http_enterprise/client/README.md
@@ -1,0 +1,33 @@
+# Enterprise HTTP Client
+
+Demonstrates tokens, multitenancy, and signed requests against the enterprise server.
+
+## Run
+
+**Start the server** (separate terminal):
+
+```bash
+cd examples/http_enterprise/server
+go run .
+```
+
+**Run the client**:
+
+```bash
+cd examples/http_enterprise/client
+go run .
+```
+
+## What It Does
+
+- Authenticates with Bearer tokens
+- Uses HMAC signing for request integrity
+- Demonstrates tenant isolation
+- Shows idempotency key usage
+
+**Demo tokens** (baked into example):
+- `admin-token`
+- `user-token`
+- `globex-token`
+
+For more details, see [examples/http_enterprise/README.md](../README.md).

--- a/examples/http_enterprise/server/README.md
+++ b/examples/http_enterprise/server/README.md
@@ -1,0 +1,32 @@
+# Enterprise HTTP Server
+
+Production-style server with authentication (Bearer/HMAC), multitenancy, rate limiting, and structured logging.
+
+## Run
+
+```bash
+cd examples/http_enterprise/server
+go run .
+```
+
+Server listens on `:8080`.
+
+## Next Steps
+
+Run the matching client:
+
+```bash
+cd examples/http_enterprise/client
+go run .
+```
+
+## Features
+
+- Bearer token authentication
+- HMAC request signing
+- Multitenancy support
+- Rate limiting
+- Structured error responses
+- Idempotency keys
+
+For deeper documentation, see [examples/http_enterprise/README.md](../README.md).

--- a/examples/inmem/README.md
+++ b/examples/inmem/README.md
@@ -1,0 +1,21 @@
+# In-Memory Store + Transport
+
+Great for learning and testing. No external services required.
+
+## Run
+
+```bash
+cd examples/inmem
+go run .
+```
+
+## What It Does
+
+- Uses in-memory storage (no database needed)
+- Uses in-memory transport (no network)
+- Demonstrates basic sync operations
+- Perfect for understanding core concepts
+
+All state lives in memory and is lost when the program exits.
+
+See also: [Quickstart Local-Only](../quickstart/local-only/README.md)

--- a/examples/intermediate/05-realtime-autosync/README.md
+++ b/examples/intermediate/05-realtime-autosync/README.md
@@ -1,0 +1,28 @@
+# Realtime Auto-Sync
+
+Demonstrates timers, background sync, and graceful shutdown patterns.
+
+## Run
+
+```bash
+cd examples/intermediate/05-realtime-autosync
+go run .
+```
+
+## What It Does
+
+- Automatic periodic sync with configurable intervals
+- Background goroutine management
+- Graceful shutdown on SIGINT/SIGTERM
+- Uses SQLite for persistence
+
+**Artifact**: Creates `autosync.db` in the current directory (safe to delete between runs).
+
+## Key Concepts
+
+- `StartAutoSync()` / `StopAutoSync()`
+- Signal handling
+- Context cancellation
+- Clean resource cleanup
+
+See also: [State Machine Enhancements](../10-state-machine-enhancements/README.md)

--- a/examples/intermediate/06-custom-events-filters/README.md
+++ b/examples/intermediate/06-custom-events-filters/README.md
@@ -1,0 +1,26 @@
+# Custom Events & Filters
+
+Shows selective sync by event type and metadata filtering.
+
+## Run
+
+```bash
+cd examples/intermediate/06-custom-events-filters
+go run .
+```
+
+## What It Does
+
+- Filter events by type during sync
+- Filter events by custom metadata fields
+- Implement custom event interfaces
+- Demonstrate selective synchronization
+
+## Use Cases
+
+- Syncing only specific event types (e.g., orders, not analytics)
+- Tenant-specific filtering
+- Priority-based sync
+- Reducing bandwidth for large event streams
+
+See also: [Events and Storage](../03-events-and-storage/README.md), [HTTP Query Filtering](../../HTTP_EXAMPLES.md)

--- a/examples/quickstart/http-client/README.md
+++ b/examples/quickstart/http-client/README.md
@@ -1,0 +1,28 @@
+# Quickstart: HTTP Client
+
+Smallest possible client that talks to the simple HTTP server.
+
+## Run
+
+**Start the server** (separate terminal):
+
+```bash
+cd examples/http_server
+go run main.go
+```
+
+**Run the client**:
+
+```bash
+cd examples/quickstart/http-client
+go run .
+```
+
+## What It Does
+
+- Minimal HTTP client setup
+- Connects to `http://localhost:8080/sync`
+- Demonstrates basic push/pull operations
+- Perfect first step after local-only quickstart
+
+See also: [Local-Only Quickstart](../local-only/README.md), [HTTP Server](../../http_server/README.md)

--- a/examples/quickstart/local-only/README.md
+++ b/examples/quickstart/local-only/README.md
@@ -1,0 +1,25 @@
+# Quickstart: Local Only
+
+Local store with null transport. No network needed.
+
+## Run
+
+```bash
+cd examples/quickstart/local-only
+go run .
+```
+
+## What It Does
+
+- In-memory store (`memstore`)
+- Null transport (local-only, no network)
+- Basic event creation and sync
+- Simplest possible go-sync-kit setup
+
+Perfect for understanding core concepts without external dependencies.
+
+## Next Steps
+
+Once you understand local-only sync, try:
+- [HTTP Client Quickstart](../http-client/README.md) - Add network sync
+- [In-Memory Example](../../inmem/README.md) - Similar pattern with more details


### PR DESCRIPTION
## Purpose

Improve example discoverability and ease of use by adding local READMEs to 8 previously undocumented example directories.

## What's Included

### 8 New README.md Files

**Quickstart (2 files):**
1. Examples/quickstart/local-only/README.md - Simplest setup with in-memory store
2. Examples/quickstart/http-client/README.md - Minimal HTTP client

**HTTP Examples (3 files):**
3. Examples/http_client/README.md - Standalone HTTP client
4. Examples/http_enterprise/server/README.md - Production-style server with auth
5. Examples/http_enterprise/client/README.md - Enterprise client with tokens

**Other (3 files):**
6. Examples/inmem/README.md - In-memory store + transport
7. Examples/intermediate/05-realtime-autosync/README.md - Timers and background sync
8. Examples/intermediate/06-custom-events-filters/README.md - Selective sync patterns

### Updated Index

- Updated Examples/README.md with complete links to all examples
- Added explicit links to quickstart subdirectories
- Added links to enterprise client/server subdirectories
- Added entries for intermediate examples 05 and 06

## Consistent Pattern

All new READMEs follow the same structure:

`markdown
# [Example Name]

[1-line description]

## Run
\\\ash
cd examples/[path]
go run .
\\\

[Optional: What It Does, artifacts, related links]
`

## Benefits

✅ **Discoverability**: Every example directory now has documentation  
✅ **Onboarding**: Clear run commands visible in each directory  
✅ **Consistency**: Same pattern across all 15+ examples  
✅ **GitHub UI**: READMEs display automatically in GitHub directory listings  
✅ **Quick Start**: Every example runnable in ≤2 commands

## Testing

- Verified xamples/go.mod exists (shared dependencies)
- All run commands follow pattern: cd examples/X && go run .
- Cross-references between examples are working links

## Files Changed

- 8 new README.md files
- 1 updated index (examples/README.md)
- **Total**: 9 files, 238 insertions, 3 deletions

## Notes

- Maintains existing examples/go.mod for shared dependencies
- No code changes, documentation only
- All paths are relative and work from repo root